### PR TITLE
Added fluent interface for building emails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,49 @@
+# Created by https://www.gitignore.io
+
+### Intellij ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm
+
+*.iml
+
+## Directory-based project format:
+.idea/
+# if you remove the above rule, at least ignore the following:
+
+# User-specific stuff:
+# .idea/workspace.xml
+# .idea/tasks.xml
+# .idea/dictionaries
+
+# Sensitive or high-churn files:
+# .idea/dataSources.ids
+# .idea/dataSources.xml
+# .idea/sqlDataSources.xml
+# .idea/dynamic.xml
+# .idea/uiDesigner.xml
+
+# Gradle:
+# .idea/gradle.xml
+# .idea/libraries
+
+# Mongo Explorer plugin:
+# .idea/mongoSettings.xml
+
+## File-based project format:
+*.ipr
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties

--- a/src/main/java/org/codemonkey/simplejavamail/Email.java
+++ b/src/main/java/org/codemonkey/simplejavamail/Email.java
@@ -12,7 +12,7 @@ import javax.mail.util.ByteArrayDataSource;
 
 /**
  * Email message with all necessary data for an effective mailing action, including attachments etc.
- * 
+ *
  * @author Benny Bottema
  */
 public class Email {
@@ -72,7 +72,7 @@ public class Email {
 
 	/**
 	 * Sets the sender address.
-	 * 
+	 *
 	 * @param name The sender's name.
 	 * @param fromAddress The sender's email address.
 	 */
@@ -82,7 +82,7 @@ public class Email {
 
 	/**
 	 * Sets the reply-to address (optional).
-	 * 
+	 *
 	 * @param name The replied-to-receiver name.
 	 * @param replyToAddress The replied-to-receiver email address.
 	 */
@@ -113,7 +113,7 @@ public class Email {
 
 	/**
 	 * Adds a new {@link Recipient} to the list on account of name, address and recipient type (eg. {@link RecipientType#CC}).
-	 * 
+	 *
 	 * @param name The name of the recipient.
 	 * @param address The emailadres of the recipient.
 	 * @param type The type of receiver (eg. {@link RecipientType#CC}).
@@ -129,7 +129,7 @@ public class Email {
 	 * Adds an embedded image (attachment type) to the email message and generates the necessary {@link DataSource} with the given byte
 	 * data. Then delegates to {@link #addEmbeddedImage(String, DataSource)}. At this point the datasource is actually a
 	 * {@link ByteArrayDataSource}.
-	 * 
+	 *
 	 * @param name The name of the image as being referred to from the message content body (eg. '&lt;cid:signature&gt;').
 	 * @param data The byte data of the image to be embedded.
 	 * @param mimetype The content type of the given data (eg. "image/gif" or "image/jpeg").
@@ -144,7 +144,7 @@ public class Email {
 
 	/**
 	 * Overloaded method which sets an embedded image on account of name and {@link DataSource}.
-	 * 
+	 *
 	 * @param name The name of the image as being referred to from the message content body (eg. '&lt;cid:embeddedimage&gt;').
 	 * @param imagedata The image data.
 	 */
@@ -156,7 +156,7 @@ public class Email {
 	 * Adds a header to the {@link #headers} list. The value is stored as a <code>String</code>.
 	 * <p>
 	 * example: <code>email.addHeader("X-Priority", 2)</code>
-	 * 
+	 *
 	 * @param name The name of the header.
 	 * @param value The value of the header, which will be stored using {@link String#valueOf(Object)}.
 	 */
@@ -167,7 +167,7 @@ public class Email {
 	/**
 	 * Adds an attachment to the email message and generates the necessary {@link DataSource} with the given byte data. Then delegates to
 	 * {@link #addAttachment(String, DataSource)}. At this point the datasource is actually a {@link ByteArrayDataSource}.
-	 * 
+	 *
 	 * @param name The name of the extension (eg. filename including extension).
 	 * @param data The byte data of the attachment.
 	 * @param mimetype The content type of the given data (eg. "plain/text", "image/gif" or "application/pdf").
@@ -182,7 +182,7 @@ public class Email {
 
 	/**
 	 * Overloaded method which sets an attachment on account of name and {@link DataSource}.
-	 * 
+	 *
 	 * @param name The name of the attachment (eg. 'filename.ext').
 	 * @param filedata The attachment data.
 	 */
@@ -251,5 +251,277 @@ public class Email {
 	 */
 	public Map<String, String> getHeaders() {
 		return Collections.unmodifiableMap(headers);
+	}
+
+	/**
+	 * Fluent interface Builder for Emails
+	 * @author Jared Stewart
+	 */
+	public static class Builder {
+		private Recipient fromRecipient;
+		/**
+		 * The reply-to-address, optional. Can be used in conjunction with {@link #fromRecipient}.
+		 */
+		private Recipient replyToRecipient;
+
+		/**
+		 * The email message body in plain text.
+		 */
+		private String text;
+
+		/**
+		 * The email message body in html.
+		 */
+		private String textHTML;
+
+		/**
+		 * The subject of the email message.
+		 */
+		private String subject;
+
+		/**
+		 * List of {@link Recipient}.
+		 */
+		private final List<Recipient> recipients;
+
+		/**
+		 * List of {@link AttachmentResource}.
+		 */
+		private final List<AttachmentResource> embeddedImages;
+
+		/**
+		 * List of {@link AttachmentResource}.
+		 */
+		private final List<AttachmentResource> attachments;
+
+		/**
+		 * Map of header name and values, such as <code>X-Priority</code> etc.
+		 */
+		private final Map<String, String> headers;
+
+		private Email email;
+
+		public Builder() {
+			recipients = new ArrayList<Recipient>();
+			embeddedImages = new ArrayList<AttachmentResource>();
+			attachments = new ArrayList<AttachmentResource>();
+			headers = new HashMap<String, String>();
+		}
+
+		/**
+		 *
+		 */
+		public Email build() {
+			return new Email(this);
+		}
+
+		/**
+		 * Sets the sender address.
+		 *
+		 * @param name The sender's name.
+		 * @param fromAddress The sender's email address.
+		 */
+		public Builder from(final String name, final String fromAddress){
+			this.fromRecipient = new Recipient(name, fromAddress, null);
+			return this;
+		}
+
+		/**
+		 * Sets the reply-to address (optional).
+		 *
+		 * @param name The replied-to-receiver name.
+		 * @param replyToAddress The replied-to-receiver email address.
+		 */
+		public Builder replyTo(final String name, final String replyToAddress) {
+			this.replyToRecipient = new Recipient(name, replyToAddress, null);
+			return this;
+		}
+
+
+		/**
+		 * Sets the {@link #subject}.
+		 */
+		public Builder subject(final String subject) {
+			this.subject = subject;
+			return this;
+		}
+
+		/**
+		 * Sets the {@link #text}.
+		 */
+		public Builder text(final String text) {
+			this.text = text;
+			return this;
+		}
+
+		/**
+		 * Sets the {@link #textHTML}.
+		 */
+		public Builder textHTML(final String textHTML) {
+			this.textHTML = textHTML;
+			return this;
+		}
+
+		/**
+		 * Adds a new {@link Recipient} to the list on account of name, address with recipient type {@link RecipientType#TO}.
+		 *
+		 * @param name The name of the recipient.
+		 * @param address The emailaddress of the recipient.
+		 * @see #recipients
+		 * @see Recipient
+		 */
+		public Builder to(final String name, final String address) {
+			recipients.add(new Recipient(name, address, RecipientType.TO));
+			return this;
+		}
+
+		/**
+		 * Adds a new {@link Recipient} to the list on account of name, address with recipient type {@link RecipientType#TO}.
+		 *
+		 * @param recipient The recipent whose name and address to use
+		 * @see #recipients
+		 * @see Recipient
+		 */
+		public Builder to(final Recipient recipient) {
+			recipients.add(new Recipient(recipient.getName(), recipient.getAddress(), RecipientType.TO));
+			return this;
+		}
+
+
+
+		/**
+		 * Adds a new {@link Recipient} to the list on account of name, address with recipient type {@link RecipientType#CC}.
+		 *
+		 * @param name The name of the recipient.
+		 * @param address The emailaddress of the recipient.
+		 * @see #recipients
+		 * @see Recipient
+		 */
+		public Builder cc(final String name, final String address) {
+			recipients.add(new Recipient(name, address, RecipientType.CC));
+			return this;
+		}
+
+		/**
+		 * Adds a new {@link Recipient} to the list on account of name, address with recipient type {@link RecipientType#CC}.
+		 *
+		 * @param recipient The recipent whose name and address to use
+		 * @see #recipients
+		 * @see Recipient
+		 */
+		public Builder cc(final Recipient recipient) {
+			recipients.add(new Recipient(recipient.getName(), recipient.getAddress(), RecipientType.TO));
+			return this;
+		}
+
+		/**
+		 * Adds a new {@link Recipient} to the list on account of name, address with recipient type {@link RecipientType#BCC}.
+		 *
+		 * @param name The name of the recipient.
+		 * @param address The emailaddress of the recipient.
+		 * @see #recipients
+		 * @see Recipient
+		 */
+		public Builder bcc(final String name, final String address) {
+			recipients.add(new Recipient(name, address, RecipientType.BCC));
+			return this;
+		}
+
+		/**
+		 * Adds a new {@link Recipient} to the list on account of name, address with recipient type {@link RecipientType#BCC}.
+		 *
+		 * @param recipient The recipent whose name and address to use
+		 * @see #recipients
+		 * @see Recipient
+		 */
+		public Builder bcc(final Recipient recipient) {
+			recipients.add(new Recipient(recipient.getName(), recipient.getAddress(), RecipientType.TO));
+			return this;
+		}
+
+		/**
+		 * Adds an embedded image (attachment type) to the email message and generates the necessary {@link DataSource} with the given byte
+		 * data. Then delegates to {@link #addEmbeddedImage(String, DataSource)}. At this point the datasource is actually a
+		 * {@link ByteArrayDataSource}.
+		 *
+		 * @param name The name of the image as being referred to from the message content body (eg. '&lt;cid:signature&gt;').
+		 * @param data The byte data of the image to be embedded.
+		 * @param mimetype The content type of the given data (eg. "image/gif" or "image/jpeg").
+		 * @see ByteArrayDataSource
+		 * @see #addEmbeddedImage(String, DataSource)
+		 */
+		public Builder embedImage(final String name, final byte[] data, final String mimetype) {
+			final ByteArrayDataSource dataSource = new ByteArrayDataSource(data, mimetype);
+			dataSource.setName(name);
+			return embedImage(name, dataSource);
+		}
+
+		/**
+		 * Overloaded method which sets an embedded image on account of name and {@link DataSource}.
+		 *
+		 * @param name The name of the image as being referred to from the message content body (eg. '&lt;cid:embeddedimage&gt;').
+		 * @param imagedata The image data.
+		 */
+		public Builder embedImage(final String name, final DataSource imagedata) {
+			embeddedImages.add(new AttachmentResource(name, imagedata));
+			return this;
+		}
+
+		/**
+		 * Adds a header to the {@link #headers} list. The value is stored as a <code>String</code>.
+		 * <p>
+		 * example: <code>email.addHeader("X-Priority", 2)</code>
+		 *
+		 * @param name The name of the header.
+		 * @param value The value of the header, which will be stored using {@link String#valueOf(Object)}.
+		 */
+		public Builder addHeader(final String name, final Object value) {
+			headers.put(name, String.valueOf(value));
+			return this;
+		}
+
+		/**
+		 * Adds an attachment to the email message and generates the necessary {@link DataSource} with the given byte data. Then delegates to
+		 * {@link #addAttachment(String, DataSource)}. At this point the datasource is actually a {@link ByteArrayDataSource}.
+		 *
+		 * @param name The name of the extension (eg. filename including extension).
+		 * @param data The byte data of the attachment.
+		 * @param mimetype The content type of the given data (eg. "plain/text", "image/gif" or "application/pdf").
+		 * @see ByteArrayDataSource
+		 * @see #addAttachment(String, DataSource)
+		 */
+		public void addAttachment(final String name, final byte[] data, final String mimetype) {
+			final ByteArrayDataSource dataSource = new ByteArrayDataSource(data, mimetype);
+			dataSource.setName(name);
+			addAttachment(name, dataSource);
+		}
+
+		/**
+		 * Overloaded method which sets an attachment on account of name and {@link DataSource}.
+		 *
+		 * @param name The name of the attachment (eg. 'filename.ext').
+		 * @param filedata The attachment data.
+		 */
+		public void addAttachment(final String name, final DataSource filedata) {
+			attachments.add(new AttachmentResource(name, filedata));
+		}
+
+	}
+
+	/**
+	 * Constructor for the Builder class
+	 * @param builder The builder from which to create the email.
+	 */
+	private Email(Builder builder) {
+		recipients = builder.recipients;
+		embeddedImages = builder.embeddedImages;
+		attachments = builder.attachments;
+		headers = builder.headers;
+
+		fromRecipient = builder.fromRecipient;
+		replyToRecipient = builder.replyToRecipient;
+		text = builder.text;
+		textHTML = builder.textHTML;
+		subject = builder.subject;
 	}
 }


### PR DESCRIPTION
Hi Benny.  I started working on a branch to convert the build to gradle, but things got a bit hairy so for now I've put that back on the shelf.  I've implemented the Builder pattern from Effective Java by Joshua Bloch to provide a fluent interface for building Emails:

Email email = new Email.Builder().from("Jared", "stewart.jared@gmail.com")
				.to("Benny", "b.bottema@projectnibble.org")
				.subject("Pull Request")
				.text("Pull request is submitted!")
				.build();