### PR TITLE
Correct recipient type for email builder cc and bcc

### DIFF
--- a/src/main/java/org/codemonkey/simplejavamail/Email.java
+++ b/src/main/java/org/codemonkey/simplejavamail/Email.java
@@ -410,7 +410,7 @@ public class Email {
 		 * @see Recipient
 		 */
 		public Builder cc(final Recipient recipient) {
-			recipients.add(new Recipient(recipient.getName(), recipient.getAddress(), RecipientType.TO));
+			recipients.add(new Recipient(recipient.getName(), recipient.getAddress(), RecipientType.CC));
 			return this;
 		}
 
@@ -435,7 +435,7 @@ public class Email {
 		 * @see Recipient
 		 */
 		public Builder bcc(final Recipient recipient) {
-			recipients.add(new Recipient(recipient.getName(), recipient.getAddress(), RecipientType.TO));
+			recipients.add(new Recipient(recipient.getName(), recipient.getAddress(), RecipientType.BCC));
 			return this;
 		}
 


### PR DESCRIPTION
The builder has cc and bcc methods that take a recipient.  The new recipient created from the one passed in has the RecipientType set to 'TO'.  I would expect it to be set to RecipientType.CC, or RecipientType.BCC.