### PR TITLE
Add ability to use custom MimeMessage implementation (e.g. to override the default Message-ID generation strategy)

### DIFF
--- a/src/main/java/org/simplejavamail/converter/internal/mimemessage/MimeMessageHelper.java
+++ b/src/main/java/org/simplejavamail/converter/internal/mimemessage/MimeMessageHelper.java
@@ -40,11 +40,11 @@ public final class MimeMessageHelper {
 
 	/**
 	 * Creates a new {@link MimeMessage} instance coupled to a specific {@link Session} instance and prepares it in the email structure, so that it
-	 * can be filled and send.
+	 * can be filled and sent.
 	 * <p/>
-	 * Fills subject, from,reply-to, content, sent-date, recipients, texts, embedded images, attachments, content and adds all headers.
+	 * Fills subject, from, reply-to, content, sent-date, recipients, texts, embedded images, attachments, content and adds all headers.
 	 *
-	 * @param email   The email message from which the subject and From-address are extracted.
+	 * @param email   The email message from which the {@link MimeMessage} is created.
 	 * @param session The Session to attach the MimeMessage to
 	 * @return A fully preparated {@link Message} instance, ready to be sent.
 	 * @throws MessagingException           May be thrown when the message couldn't be processed by JavaMail.
@@ -64,7 +64,7 @@ public final class MimeMessageHelper {
 		}
 		// create new wrapper for each mail being sent (enable sending multiple emails with one mailer)
 		final MimeEmailMessageWrapper messageRoot = new MimeEmailMessageWrapper();
-		final MimeMessage message = new MimeMessage(session);
+		final MimeMessage message = email.createMimeMessage(session);
 		// set basic email properties
 		message.setSubject(email.getSubject(), CHARACTER_ENCODING);
 		message.setFrom(new InternetAddress(email.getFromRecipient().getAddress(), email.getFromRecipient().getName(), CHARACTER_ENCODING));

--- a/src/main/java/org/simplejavamail/email/Email.java
+++ b/src/main/java/org/simplejavamail/email/Email.java
@@ -6,6 +6,8 @@ import javax.activation.DataSource;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.mail.Message.RecipientType;
+import javax.mail.Session;
+import javax.mail.internet.MimeMessage;
 import javax.mail.util.ByteArrayDataSource;
 import java.io.File;
 import java.io.InputStream;
@@ -137,6 +139,17 @@ public class Email {
 				setSubject((String) getProperty(DEFAULT_SUBJECT));
 			}
 		}
+	}
+
+	/**
+	 * Factory method to generate a {@link MimeMessage}. Subclasses can override this method to produce a custom
+	 * implementation of {@link MimeMessage} (e.g. one that overrides the default message id generation strategy).
+	 *
+	 * @param session The Session to attach the MimeMessage to
+	 * @return A blank {@link MimeMessage} instance to be populated.
+	 */
+	public MimeMessage createMimeMessage(@Nonnull Session session) {
+		return new MimeMessage(session);
 	}
 
 	/**


### PR DESCRIPTION
**Problem:**
By default, JavaMail generates a Message-ID that contains the machine's name. This is done in `MimeMessage.updateMessageID()`. I would like to be able to set my own Message-ID.

Normally, you would override this method. [According to the javadoc](https://github.com/javaee/javamail/blob/master/mail/src/main/java/javax/mail/internet/MimeMessage.java#L2227-L2239) for `MimeMessage.updateMessageID()`:
> Update the Message-ID header.  [...] allows a subclass to override only the algorithm for choosing a Message-ID.

There is no way to do this however through Simple Java Mail, as the construction of the MimeMessage and the saving of it [is done in Mailer and cannot be overridden](https://github.com/bbottema/simple-java-mail/blob/master/src/main/java/org/simplejavamail/mailer/internal/mailsender/MailSender.java#L185-L188).

One solution Apache Commons Mail provides for this, is [it has a factory method for the creation of the MimeMessage](https://github.com/apache/commons-email/blob/trunk/src/main/java/org/apache/commons/mail/Email.java#L1891-L1901) which you can override. I really love the fluent API Simple Java Mail provides; the only issue preventing me using it instead of Apache Commons Mail is the ability to set a different Message-ID generation strategy

**Solution:**
Add a method to `org.simplejavamail.email.Email`:
```
public MimeMessage createMimeMessage(final Session session) {
    return new MimeMessage(session);
}
```
Use this method in [MimeMessageHelper:L67](https://github.com/bbottema/simple-java-mail/blob/master/src/main/java/org/simplejavamail/converter/internal/mimemessage/MimeMessageHelper.java#L67):
```
- final MimeMessage message = new MimeMessage(session);
+ final MimeMessage message = email.createMimeMessage(session);
```

This way, users of the library can use their own custom implementations of MimeMessage:
```
Email htmlEmail = new Email() {
    @Override
    public MimeMessage createMimeMessage(Session session) {
        return new MimeMessage(session) {
            @Override
            protected void updateMessageID() throws MessagingException {
                setHeader("Message-ID", myMessageIdGenerationStrategy());
            }
        };
    }
};
```