### PR TITLE
Add timeouts to SMTP transport sockets

### DIFF
--- a/src/main/java/org/simplejavamail/mailer/Mailer.java
+++ b/src/main/java/org/simplejavamail/mailer/Mailer.java
@@ -86,10 +86,10 @@ public class Mailer {
 	private static final Logger LOGGER = LoggerFactory.getLogger(Mailer.class);
 
 	/**
-	 * the default maximum timeout value for the transport socket is {@value #DEFAULT_SEND_MAIL_SOCKET_TIMEOUT}
+	 * The default maximum timeout value for the transport socket is {@value #DEFAULT_MAIL_SOCKET_TIMEOUT}
 	 * milliseconds. Can be overridden from a config file or through System variable.
 	 */
-	private static final String DEFAULT_SEND_MAIL_SOCKET_TIMEOUT = "60000";
+	private static final String DEFAULT_MAIL_SOCKET_TIMEOUT = "60000";
 
 	private final MailSender mailSender;
 
@@ -239,7 +239,7 @@ public class Mailer {
 
 		// socket timeouts handling
 		String sendMailTimeoutInMillis = ConfigLoader.valueOrProperty(
-			null, Property.DEFAULT_SEND_MAIL_TIMEOUT_IN_MILLIS, DEFAULT_SEND_MAIL_SOCKET_TIMEOUT
+			null, Property.DEFAULT_MAIL_SOCKET_TIMEOUT_IN_MILLIS, DEFAULT_MAIL_SOCKET_TIMEOUT
 		);
 		props.put("mail.smtp.connectiontimeout", sendMailTimeoutInMillis);
 		props.put("mail.smtp.timeout", sendMailTimeoutInMillis);

--- a/src/main/java/org/simplejavamail/mailer/Mailer.java
+++ b/src/main/java/org/simplejavamail/mailer/Mailer.java
@@ -10,6 +10,8 @@ import org.simplejavamail.mailer.config.ServerConfig;
 import org.simplejavamail.mailer.config.TransportStrategy;
 import org.simplejavamail.mailer.internal.mailsender.MailSender;
 import org.simplejavamail.converter.internal.mimemessage.MimeMessageHelper;
+import org.simplejavamail.util.ConfigLoader;
+import org.simplejavamail.util.ConfigLoader.Property;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,6 +84,12 @@ import static org.simplejavamail.util.ConfigLoader.Property.TRANSPORT_STRATEGY;
 public class Mailer {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(Mailer.class);
+
+	/**
+	 * the default maximum timeout value for the transport socket is {@value #DEFAULT_SEND_MAIL_SOCKET_TIMEOUT}
+	 * milliseconds. Can be overridden from a config file or through System variable.
+	 */
+	private static final String DEFAULT_SEND_MAIL_SOCKET_TIMEOUT = "60000";
 
 	private final MailSender mailSender;
 
@@ -228,6 +236,14 @@ public class Mailer {
 		final Properties props = transportStrategy.generateProperties();
 		props.put(transportStrategy.propertyNameHost(), serverConfig.getHost());
 		props.put(transportStrategy.propertyNamePort(), String.valueOf(serverConfig.getPort()));
+
+		// socket timeouts handling
+		String sendMailTimeoutInMillis = ConfigLoader.valueOrProperty(
+			null, Property.DEFAULT_SEND_MAIL_TIMEOUT_IN_MILLIS, DEFAULT_SEND_MAIL_SOCKET_TIMEOUT
+		);
+		props.put("mail.smtp.connectiontimeout", sendMailTimeoutInMillis);
+		props.put("mail.smtp.timeout", sendMailTimeoutInMillis);
+		props.put("mail.smtp.writetimeout", sendMailTimeoutInMillis);
 
 		if (serverConfig.getUsername() != null) {
 			props.put(transportStrategy.propertyNameUsername(), serverConfig.getUsername());

--- a/src/main/java/org/simplejavamail/mailer/internal/mailsender/MailSender.java
+++ b/src/main/java/org/simplejavamail/mailer/internal/mailsender/MailSender.java
@@ -163,6 +163,8 @@ public class MailSender {
 				executor = Executors.newFixedThreadPool(threadPoolSize);
 			}
 			executor.execute(new Runnable() {
+				private final String name = "sendMail process";
+
 				@Override
 				public void run() {
 					try {
@@ -170,6 +172,11 @@ public class MailSender {
 					} catch (Exception e) {
 						LOGGER.error("could not send email {}", email, e);
 					}
+				}
+
+				@Override
+				public String toString() {
+					return name;
 				}
 			});
 		} else {

--- a/src/main/java/org/simplejavamail/mailer/internal/mailsender/MailSender.java
+++ b/src/main/java/org/simplejavamail/mailer/internal/mailsender/MailSender.java
@@ -162,10 +162,14 @@ public class MailSender {
 			if (executor == null || executor.isTerminated()) {
 				executor = Executors.newFixedThreadPool(threadPoolSize);
 			}
-			executor.execute(new Thread("sendMail process") {
+			executor.execute(new Runnable() {
 				@Override
 				public void run() {
-					sendMailClosure(session, email);
+					try {
+						sendMailClosure(session, email);
+					} catch (Exception e) {
+						LOGGER.trace("could not send email '{}' to {}", email.getSubject(), email.getRecipients(), e);
+					}
 				}
 			});
 		} else {

--- a/src/main/java/org/simplejavamail/mailer/internal/mailsender/MailSender.java
+++ b/src/main/java/org/simplejavamail/mailer/internal/mailsender/MailSender.java
@@ -163,7 +163,7 @@ public class MailSender {
 				executor = Executors.newFixedThreadPool(threadPoolSize);
 			}
 			executor.execute(new Runnable() {
-				private final String name = "sendMail process";
+				private static final String NAME = "sendMail process";
 
 				@Override
 				public void run() {
@@ -176,7 +176,7 @@ public class MailSender {
 
 				@Override
 				public String toString() {
-					return name;
+					return NAME;
 				}
 			});
 		} else {

--- a/src/main/java/org/simplejavamail/mailer/internal/mailsender/MailSender.java
+++ b/src/main/java/org/simplejavamail/mailer/internal/mailsender/MailSender.java
@@ -168,7 +168,7 @@ public class MailSender {
 					try {
 						sendMailClosure(session, email);
 					} catch (Exception e) {
-						LOGGER.trace("could not send email '{}' to {}", email.getSubject(), email.getRecipients(), e);
+						LOGGER.error("could not send email {}", email, e);
 					}
 				}
 			});

--- a/src/main/java/org/simplejavamail/util/ConfigLoader.java
+++ b/src/main/java/org/simplejavamail/util/ConfigLoader.java
@@ -94,7 +94,7 @@ public final class ConfigLoader {
 		DEFAULT_BCC_NAME("simplejavamail.defaults.bcc.name"),
 		DEFAULT_BCC_ADDRESS("simplejavamail.defaults.bcc.address"),
 		DEFAULT_POOL_SIZE("simplejavamail.defaults.poolsize"),
-		DEFAULT_SEND_MAIL_TIMEOUT_IN_MILLIS("simplejavamail.defaults.sendmailtimeoutinmillis"),
+		DEFAULT_MAIL_SOCKET_TIMEOUT_IN_MILLIS("simplejavamail.defaults.mailsockettimeoutinmillis"),
 		TRANSPORT_MODE_LOGGING_ONLY("simplejavamail.transport.mode.logging.only");
 
 		private final String key;

--- a/src/main/java/org/simplejavamail/util/ConfigLoader.java
+++ b/src/main/java/org/simplejavamail/util/ConfigLoader.java
@@ -94,6 +94,7 @@ public final class ConfigLoader {
 		DEFAULT_BCC_NAME("simplejavamail.defaults.bcc.name"),
 		DEFAULT_BCC_ADDRESS("simplejavamail.defaults.bcc.address"),
 		DEFAULT_POOL_SIZE("simplejavamail.defaults.poolsize"),
+		DEFAULT_SEND_MAIL_TIMEOUT_IN_MILLIS("simplejavamail.defaults.sendmailtimeoutinmillis"),
 		TRANSPORT_MODE_LOGGING_ONLY("simplejavamail.transport.mode.logging.only");
 
 		private final String key;


### PR DESCRIPTION
This merge request is related to issue #85.<br /><br />So actually the timeouts added for transport sockets will be used for synchronous and asynchronous emails. <br />These timeouts can be configured via the property `simplejavamail.defaults.mailsockettimeoutinmillis`. The default is 1 minute.<br /><br />At first I tried to implement the solution described at https://stackoverflow.com/a/2759040/3790208, but I realized it didn't work with raw `Socket` objects :(. That's when I discovered that various options including timeouts can be passed to the javax-mail socket factory `SocketFetcher`. So since my implementation would complicate `MailSender`, I put it aside.<br />However controlling timeout at the thread level enables to configure the timeout for the whole send mail process instead of the timeout of each socket operation.<br />So if for whatever reason you want to control the timeout at the thread level, you can:<br />- tell `SocketFetcher` to use `SocketChannel` which is an interruptible `Socket` trough the property `mail.smtp.usesocketchannels`,<br />- replace the `ExecutorService` in `MailSender` by `TimeoutTaskThreadPoolExecutor`: https://gist.github.com/amanteaux/64c54a913c1ae34ad7b86db109cbc0bf