### PR TITLE
Fix mail.smtp.ssl.trust to be space-delimited

### DIFF
--- a/src/main/java/org/simplejavamail/mailer/Mailer.java
+++ b/src/main/java/org/simplejavamail/mailer/Mailer.java
@@ -313,10 +313,20 @@ public class Mailer {
 	}
 
 	/**
-	 * Configures the current session to white list all provided hosts and don't validate SSL keys for them. The property "mail.smtp.ssl.trust" is set
-	 * to a comma separated list.
+	 * Configures the current session to only accept server certificates issued to one of the provided hostnames,
+	 * <strong>and disables certificate issuer validation.</strong>
 	 * <p>
-	 * Refer to https://javamail.java.net/nonav/docs/api/com/sun/mail/smtp/package-summary.html#mail.smtp.ssl.trust
+	 * Passing an empty list resets the current session's trust behavior to the default, and is equivalent to never
+	 * calling this method in the first place.
+	 * <p>
+	 * <strong>Security warning:</strong> Any certificate matching any of the provided host names will be accepted,
+	 * regardless of the certificate issuer; attackers can abuse this behavior by serving a matching self-signed
+	 * certificate during a man-in-the-middle attack.
+	 * <p>
+	 * This method sets the property {@code mail.smtp.ssl.trust} to a space-separated list of the provided
+	 * {@code hosts}. If the provided list is empty, {@code mail.smtp.ssl.trust} is unset.
+	 *
+	 * @see <a href="https://javaee.github.io/javamail/docs/api/com/sun/mail/smtp/package-summary.html#mail.smtp.ssl.trust"><code>mail.smtp.ssl.trust</code></a>
 	 */
 	public void trustSSLHosts(final String... hosts) {
 		mailSender.trustHosts(hosts);

--- a/src/main/java/org/simplejavamail/mailer/internal/mailsender/MailSender.java
+++ b/src/main/java/org/simplejavamail/mailer/internal/mailsender/MailSender.java
@@ -328,17 +328,27 @@ public class MailSender {
 	}
 
 	/**
-	 * Configures the current session to white list all provided hosts and don't validate SSL keys for them. The property "mail.smtp.ssl.trust" is set
-	 * to a comma separated list.
+	 * Configures the current session to only accept server certificates issued to one of the provided hostnames,
+	 * <strong>and disables certificate issuer validation.</strong>
 	 * <p>
-	 * Refer to https://javamail.java.net/nonav/docs/api/com/sun/mail/smtp/package-summary.html#mail.smtp.ssl.trust
+	 * Passing an empty list resets the current session's trust behavior to the default, and is equivalent to never
+	 * calling this method in the first place.
+	 * <p>
+	 * <strong>Security warning:</strong> Any certificate matching any of the provided host names will be accepted,
+	 * regardless of the certificate issuer; attackers can abuse this behavior by serving a matching self-signed
+	 * certificate during a man-in-the-middle attack.
+	 * <p>
+	 * This method sets the property {@code mail.smtp.ssl.trust} to a space-separated list of the provided
+	 * {@code hosts}. If the provided list is empty, {@code mail.smtp.ssl.trust} is unset.
+	 *
+	 * @see <a href="https://javaee.github.io/javamail/docs/api/com/sun/mail/smtp/package-summary.html#mail.smtp.ssl.trust"><code>mail.smtp.ssl.trust</code></a>
 	 */
 	public void trustHosts(final String... hosts) {
 		trustAllHosts(false);
 		if (hosts.length > 0) {
 			final StringBuilder builder = new StringBuilder(hosts[0]);
 			for (int i = 1; i < hosts.length; i++) {
-				builder.append(",").append(hosts[i]);
+				builder.append(" ").append(hosts[i]);
 			}
 			session.getProperties().setProperty("mail.smtp.ssl.trust", builder.toString());
 		}

--- a/src/test/java/org/simplejavamail/mailer/internal/mailsender/MailSenderTest.java
+++ b/src/test/java/org/simplejavamail/mailer/internal/mailsender/MailSenderTest.java
@@ -42,8 +42,8 @@ public class MailSenderTest {
 		mailSender.trustHosts("a");
 		assertThat(session.getProperties().getProperty("mail.smtp.ssl.trust")).isEqualTo("a");
 		mailSender.trustHosts("a", "b");
-		assertThat(session.getProperties().getProperty("mail.smtp.ssl.trust")).isEqualTo("a,b");
+		assertThat(session.getProperties().getProperty("mail.smtp.ssl.trust")).isEqualTo("a b");
 		mailSender.trustHosts("a", "b", "c");
-		assertThat(session.getProperties().getProperty("mail.smtp.ssl.trust")).isEqualTo("a,b,c");
+		assertThat(session.getProperties().getProperty("mail.smtp.ssl.trust")).isEqualTo("a b c");
 	}
 }


### PR DESCRIPTION
Before this change `mail.smtp.ssl.trust` values were comma-delimited, but JavaMail actually expects a space-delimited list of hosts.

Also took advantage of this opportunity to add a security warning to the `trustHosts` method, as its security implications were not well-documented until now.

Fixes #110.