### PR TITLE
replies should get their HTML text from the original HTMLText, not plainText

### DIFF
--- a/src/main/java/org/simplejavamail/email/EmailBuilder.java
+++ b/src/main/java/org/simplejavamail/email/EmailBuilder.java
@@ -300,7 +300,7 @@ public class EmailBuilder {
 					.withSubject(generatedReply.getSubject())
 					.to(generatedReply.getRecipients())
 					.withPlainText(LINE_START_PATTERN.matcher(defaultTo(repliedTo.getPlainText(), "")).replaceAll("> "))
-					.withHTMLText(format(htmlTemplate, defaultTo(repliedTo.getPlainText(), "")))
+					.withHTMLText(format(htmlTemplate, defaultTo(repliedTo.getHTMLText(), "")))
 					.withHeaders(generatedReply.getHeaders())
 					.withEmbeddedImages(repliedTo.getEmbeddedImages());
 		}


### PR DESCRIPTION
Addresses [Issue 137](https://github.com/bbottema/simple-java-mail/issues/137).

Essentially, it appears that the repliesTo email builder was relying on plainText to generate the quoted original email, rather than using the HTMLText field. 

There's probably a bunch of validation stuff I'm unaware of, this is my first foray into emailing. Let me know if i can do anything to improve the PR.