### PR TITLE
Allow threads to timeout in the thread pool

### DIFF
--- a/src/main/java/org/simplejavamail/mailer/internal/mailsender/OperationalConfig.java
+++ b/src/main/java/org/simplejavamail/mailer/internal/mailsender/OperationalConfig.java
@@ -30,6 +30,11 @@ public class OperationalConfig {
 	private final int threadPoolSize;
 	
 	/**
+	 * @see org.simplejavamail.mailer.MailerBuilder.MailerRegularBuilder#withThreadPoolTimeout(Integer)
+	 */
+	private final int threadPoolTimeout;
+	
+	/**
 	 * @see org.simplejavamail.mailer.MailerBuilder.MailerRegularBuilder#withTransportModeLoggingOnly(Boolean)
 	 */
 	private final boolean transportModeLoggingOnly;
@@ -56,6 +61,7 @@ public class OperationalConfig {
 		this.properties = properties;
 		this.sessionTimeout = sessionTimeout;
 		this.threadPoolSize = threadPoolSize;
+		this.threadPoolTimeout = 1; // TODO wire it up to all the config files
 		this.transportModeLoggingOnly = transportModeLoggingOnly;
 		this.debugLogging = debugLogging;
 		this.sslHostsToTrust = Collections.unmodifiableList(sslHostsToTrust);
@@ -75,7 +81,14 @@ public class OperationalConfig {
 	public int getThreadPoolSize() {
 		return threadPoolSize;
 	}
-	
+
+	/**
+	 * @see org.simplejavamail.mailer.MailerBuilder.MailerRegularBuilder#withThreadPoolSize(Integer)
+	 */
+	public int getThreadPoolTimeout() {
+		return threadPoolTimeout;
+	}
+
 	/**
 	 * @see org.simplejavamail.mailer.MailerBuilder.MailerRegularBuilder#withTransportModeLoggingOnly(Boolean)
 	 */


### PR DESCRIPTION
As you asked, I did not go far in the config wiring. But if this solution is ok, I can do it if you want.
Currently, I only verified on a real project that the sending thread expired correctly after 1 second. But to check that threads are correctly expiring, it is possible to write a unit test. I can do it, but I prefer first to validate this!

About the exception bubbling up in the `ThreadPoolExecutor` and not being logged through SLF4J should I create a separate issue?