### PR TITLE
allow creating email with attachment that has space in the filename

### DIFF
--- a/src/main/java/org/simplejavamail/converter/internal/mimemessage/MimeMessageHelper.java
+++ b/src/main/java/org/simplejavamail/converter/internal/mimemessage/MimeMessageHelper.java
@@ -1,5 +1,6 @@
 package org.simplejavamail.converter.internal.mimemessage;
 
+import javax.mail.internet.ParameterList;
 import net.markenwerk.utils.mail.dkim.DkimMessage;
 import net.markenwerk.utils.mail.dkim.DkimSigner;
 import org.simplejavamail.email.AttachmentResource;
@@ -260,7 +261,10 @@ public final class MimeMessageHelper {
 		attachmentPart.setDataHandler(new DataHandler(new NamedDataSource(fileName, attachmentResource.getDataSource())));
 		attachmentPart.setFileName(fileName);
 		final String contentType = attachmentResource.getDataSource().getContentType();
-		attachmentPart.setHeader("Content-Type", contentType + "; filename=" + fileName + "; name=" + resourceName);
+		ParameterList pl = new ParameterList();
+		pl.set("filename", fileName);
+		pl.set("name", resourceName);
+		attachmentPart.setHeader("Content-Type", contentType + pl.toString());
 		attachmentPart.setHeader("Content-ID", format("<%s>", resourceName));
 		attachmentPart.setDisposition(dispositionType);
 		return attachmentPart;

--- a/src/test/java/org/simplejavamail/converter/internal/mimemessage/MimeMessageHelperTest.java
+++ b/src/test/java/org/simplejavamail/converter/internal/mimemessage/MimeMessageHelperTest.java
@@ -1,5 +1,10 @@
 package org.simplejavamail.converter.internal.mimemessage;
 
+import javax.mail.BodyPart;
+import javax.mail.MessagingException;
+import javax.mail.internet.ContentType;
+import javax.mail.internet.MimeMessage;
+import javax.mail.internet.MimeMultipart;
 import org.assertj.core.api.ThrowableAssert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -130,5 +135,18 @@ public class MimeMessageHelperTest {
 			}
 		})
 				.hasMessage(MimeMessageParseException.ERROR_SIGNING_DKIM_INVALID_DOMAINKEY);
+	}
+
+	@Test
+	public void filenameWithSpaceEncoding() throws IOException, MessagingException {
+		final String fileName = "file name.txt";
+		final Email email = EmailHelper.createDummyEmailBuilder(true, true, false)
+				.clearAttachments().withAttachment(fileName, "abc".getBytes(),
+						"text/plain").buildEmail();
+		final MimeMessage mimeMessage = EmailConverter.emailToMimeMessage(email);
+		final BodyPart bodyPart = ((MimeMultipart) mimeMessage.getContent()).getBodyPart(1);
+		ContentType ct = new ContentType(bodyPart.getHeader("Content-Type")[0]);
+		assertThat(ct.getParameter("filename")).isEqualTo(fileName);
+		assertThat(bodyPart.getFileName()).isEqualTo(fileName);
 	}
 }


### PR DESCRIPTION
When creating attachment with space in file name the header Content-Type params are not valid.