### PR TITLE
Add automatic module names (fixes #245)

### DIFF
--- a/modules/authenticated-socks-module/pom.xml
+++ b/modules/authenticated-socks-module/pom.xml
@@ -17,8 +17,11 @@
     <name>Simple Java Mail - Authenticated SOCKS module</name>
     <description>Simple API, Complex Emails. Now with SOCKS5 support</description>
 
-    <dependencies>
+    <properties>
+        <automaticModuleName>org.simplejavamail.authenticatedsocks</automaticModuleName>
+    </properties>
 
+    <dependencies>
         <!-- core dependencies -->
         <dependency>
             <groupId>org.simplejavamail</groupId>

--- a/modules/batch-module/pom.xml
+++ b/modules/batch-module/pom.xml
@@ -17,6 +17,10 @@
     <name>Simple Java Mail - Batch module</name>
     <description>Simple API, Complex Emails. High performance.</description>
 
+    <properties>
+        <automaticModuleName>org.simplejavamail.batch</automaticModuleName>
+    </properties>
+
     <dependencies>
 
         <!-- core dependencies -->

--- a/modules/cli-module/pom.xml
+++ b/modules/cli-module/pom.xml
@@ -17,6 +17,10 @@
     <name>Simple Java Mail - CLI module</name>
     <description>Simple API, Complex Emails. Now with CLI support</description>
 
+    <properties>
+        <automaticModuleName>org.simplejavamail.cli</automaticModuleName>
+    </properties>
+
     <dependencies>
 
         <!-- core dependencies -->

--- a/modules/core-module/pom.xml
+++ b/modules/core-module/pom.xml
@@ -17,6 +17,10 @@
     <name>Simple Java Mail - Core module</name>
     <description>Simple API, Complex Emails. Core module support</description>
 
+    <properties>
+        <automaticModuleName>org.simplejavamail.core</automaticModuleName>
+    </properties>
+
     <dependencies>
 
         <!-- core dependencies -->

--- a/modules/core-test-module/pom.xml
+++ b/modules/core-test-module/pom.xml
@@ -17,6 +17,10 @@
     <name>Simple Java Mail - Core Test module</name>
     <description>Simple API, Complex Emails. Core module test support</description>
 
+    <properties>
+        <automaticModuleName>org.simplejavamail.test</automaticModuleName>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.simplejavamail</groupId>

--- a/modules/dkim-module/pom.xml
+++ b/modules/dkim-module/pom.xml
@@ -17,6 +17,10 @@
     <name>Simple Java Mail - DKIM module</name>
     <description>Simple API, Complex Emails. Now with DKIM support</description>
 
+    <properties>
+        <automaticModuleName>org.simplejavamail.dkim</automaticModuleName>
+    </properties>
+
     <dependencies>
 
         <!-- core dependencies -->

--- a/modules/outlook-module/pom.xml
+++ b/modules/outlook-module/pom.xml
@@ -17,6 +17,10 @@
     <name>Simple Java Mail - Outlook module</name>
     <description>Simple API, Complex Emails. Now with Outlook support</description>
 
+    <properties>
+        <automaticModuleName>org.simplejavamail.outlook</automaticModuleName>
+    </properties>
+
     <dependencies>
 
         <!-- core dependencies -->

--- a/modules/simple-java-mail/pom.xml
+++ b/modules/simple-java-mail/pom.xml
@@ -18,6 +18,7 @@
     <description>Simple API, Complex Emails. A light weight wrapper for the JavaMail SMTP API</description>
 
     <properties>
+        <automaticModuleName>org.simplejavamail</automaticModuleName>
         <spring.version>[4.3.18.RELEASE,)</spring.version>
     </properties>
 

--- a/modules/smime-module/pom.xml
+++ b/modules/smime-module/pom.xml
@@ -17,6 +17,10 @@
     <name>Simple Java Mail - S/MIME module</name>
     <description>Simple API, Complex Emails. Now with S/MIME support</description>
 
+    <properties>
+        <automaticModuleName>org.simplejavamail.smime</automaticModuleName>
+    </properties>
+
     <dependencies>
 
         <!-- core dependencies -->

--- a/modules/spring-module/pom.xml
+++ b/modules/spring-module/pom.xml
@@ -18,6 +18,7 @@
     <description>Simple API, Complex Emails. Now with Spring support</description>
 
     <properties>
+        <automaticModuleName>org.simplejavamail.spring</automaticModuleName>
         <spring.version>[4.3.18.RELEASE,)</spring.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
 
     <properties>
         <se.eris.notnull.instrument>false</se.eris.notnull.instrument>
+        <automaticModuleName>org.simplejavamail.undefined</automaticModuleName> <!-- update in individual modules -->
     </properties>
 
     <!-- to skip some steps: -DskipTests -Dspotbugs.skip=true -Dmaven.javadoc.skip=true -Denforcer.skip=true -Djacoco.skip=true -Dlicense.skip=true -->
@@ -111,6 +112,17 @@
                         <classes>**Assert</classes><!-- AssertJ generated -->
                         <classes>**.ServerReply</classes><!-- somehow gets messed up -->
                     </excludes>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automaticModuleName}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
This PR adds proper automatic module names to every JAR in the project. They can be checked inside the JAR's `META-INF/MANIFEST.MF`. Some things to consider before merging:

- People will reference these names in their module descriptors. Therefore, they should be considered public API. Please review these names and make sure you are comfortable with them, before you make them permanent.
- These names should become the proper module names, if/when #237 is worked on. The project can now be included in modular Java applications, but to achieve full modularity, the modules of this project should provide their own module descriptors.

Word of caution: on my Java 11, I still wasn't able to build the project cleanly. I have to `-DskipTests`, as plenty of tests fail with Java 11. (This PR has no effect on that, neither should it.) Also, for some reason, JaCoCo also throws a lot of exceptions, although I don't have that problem with my own projects using it.