### PR TITLE
MimeMessageHelper: use complete filename as resource name

### DIFF
--- a/modules/simple-java-mail/src/main/java/org/simplejavamail/converter/internal/mimemessage/MimeMessageHelper.java
+++ b/modules/simple-java-mail/src/main/java/org/simplejavamail/converter/internal/mimemessage/MimeMessageHelper.java
@@ -237,7 +237,7 @@ public class MimeMessageHelper {
 		final String contentType = attachmentResource.getDataSource().getContentType();
 		ParameterList pl = new ParameterList();
 		pl.set("filename", fileName);
-		pl.set("name", resourceName);
+		pl.set("name", fileName);
 		attachmentPart.setHeader("Content-Type", contentType + pl.toString());
 		attachmentPart.setHeader("Content-ID", format("<%s>", resourceName));
 		attachmentPart.setDisposition(dispositionType);


### PR DESCRIPTION
Mail for Windows 10 uses the name property of the Content-Type
as the displayed filename, regardless of the filename set.
As the Content-Type name misses the extension, attachments can
not be opened with the preferred application.

Fix this by adding the extension to the Content-Type name.