### PR TITLE
Fix compareClusterConfig

### DIFF
--- a/modules/batch-module/src/main/java/org/simplejavamail/internal/batchsupport/ClusterHelper.java
+++ b/modules/batch-module/src/main/java/org/simplejavamail/internal/batchsupport/ClusterHelper.java
@@ -37,7 +37,7 @@ final class ClusterHelper {
 
 	static boolean compareClusterConfig(@NotNull final OperationalConfig operationalConfig, final ClusterConfig<Session, Transport> config) {
 		return config.getDefaultCorePoolSize() != operationalConfig.getConnectionPoolCoreSize() ||
-				config.getDefaultMaxPoolSize() != operationalConfig.getConnectionPoolCoreSize() ||
+				config.getDefaultMaxPoolSize() != operationalConfig.getConnectionPoolMaxSize() ||
 				config.getLoadBalancingStrategy().getClass() != determineLoadBalancingStrategy(operationalConfig).getClass() ||
 				!config.getDefaultExpirationPolicy().equals(new TimeoutSinceLastAllocationExpirationPolicy<Transport>(operationalConfig.getConnectionPoolExpireAfterMillis(), MILLISECONDS));
 	}


### PR DESCRIPTION
The comparison doesn't looks right.

It could be the reason I got the following warning in my test : 

```
Global SMTP Connection pool is already configured with pool defaults from the first Mailer instance, ignoring relevant properties from OperationalConfigImpl{async=false, properties={mail.smtp.ssl.checkserveridentity=false}, sessionTimeout=60000, threadPoolSize=10, threadPoolKeepAliveTime=1, clusterKey=07ef45b7-f4d9-4f19-9377-b010852aee13, connectionPoolCoreSize=0, connectionPoolMaxSize=4, connectionPoolClaimTimeoutMillis=2147483647, connectionPoolExpireAfterMillis=5000, connectionPoolLoadBalancingStrategy=ROUND_ROBIN, transportModeLoggingOnly=false, debugLogging=false, sslHostsToTrust=[], trustAllSSLHost=true, verifyingServerIdentity=true, executorService=org.simplejavamail.internal.batchsupport.concurrent.NonJvmBlockingThreadPoolExecutor@1e1d3956[Running, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 0], customMailer=null}
```