### PR TITLE
Fix the regex for calendar parsing

### DIFF
--- a/modules/simple-java-mail/src/main/java/org/simplejavamail/converter/internal/mimemessage/MimeMessageParser.java
+++ b/modules/simple-java-mail/src/main/java/org/simplejavamail/converter/internal/mimemessage/MimeMessageParser.java
@@ -208,7 +208,7 @@ public final class MimeMessageParser {
 	 */
 	@SuppressWarnings("WeakerAccess")
 	public static String parseCalendarMethod(@NotNull MimePart currentPart) {
-		Pattern compile = Pattern.compile("method=\"(.*?)\"");
+		Pattern compile = Pattern.compile("method=\"?(\\w+)");
 		final String contentType;
 		try {
 			contentType = currentPart.getDataHandler().getContentType();


### PR DESCRIPTION
Sometimes, so far only seen on Google Calendar invites, the content type
for text/calendar doesn't include double quotes ("), like so:

    Content-Type: text/calendar; charset=UTF-8; method=CANCEL

This fix makes the matching " optional.