### PR TITLE
Decrease size of log output

### DIFF
--- a/modules/simple-java-mail/src/main/java/org/simplejavamail/mailer/internal/SendMailClosure.java
+++ b/modules/simple-java-mail/src/main/java/org/simplejavamail/mailer/internal/SendMailClosure.java
@@ -63,13 +63,16 @@ class SendMailClosure extends AbstractProxyServerSyncingClosure {
 				TransportRunner.sendMessage(operationalConfig.getClusterKey(), session, message, message.getAllRecipients());
 			}
 		} catch (final UnsupportedEncodingException e) {
-			LOGGER.error("Failed to send email:\n{}", email);
+			LOGGER.error("Failed to send email:\n{}", email.getId());
+			LOGGER.trace("{}", email);
 			throw new MailerException(MailerException.INVALID_ENCODING, e);
 		} catch (final MessagingException e) {
-			LOGGER.error("Failed to send email:\n{}", email);
+			LOGGER.error("Failed to send email:\n{}", email.getId());
+			LOGGER.trace("{}", email);
 			throw new MailerException(MailerException.GENERIC_ERROR, e);
 		} catch (final Exception e) {
-			LOGGER.error("Failed to send email:\n{}", email);
+			LOGGER.error("Failed to send email:\n{}", email.getId());
+			LOGGER.trace("{}", email);
 			throw e;
 		}
 	}


### PR DESCRIPTION
Only log the whole contents of an `Email` object on `trace` log level instead of `error`. Otherwise the whole email is printed to the logs, which can blow up the amount of logs quite a bit for services sending emails automatically.

Alternatively, the `Email.toString()` method could be changed to actually not put in *all* the contents of text/html bodies.