### PR TITLE
Add option to parse MimeMessage without fetching attachment data from server

### DIFF
--- a/modules/simple-java-mail/src/main/java/org/simplejavamail/converter/EmailConverter.java
+++ b/modules/simple-java-mail/src/main/java/org/simplejavamail/converter/EmailConverter.java
@@ -86,6 +86,14 @@ public final class EmailConverter {
 	}
 
 	/**
+	 * Delegates to {@link #mimeMessageToEmailBuilder(MimeMessage, Pkcs12Config, boolean)}.
+	 */
+	@NotNull
+	public static Email mimeMessageToEmail(@NotNull final MimeMessage mimeMessage, @Nullable final Pkcs12Config pkcs12Config, boolean attachmentData) {
+		return mimeMessageToEmailBuilder(mimeMessage, pkcs12Config, attachmentData).buildEmail();
+	}
+
+	/**
 	 * Delegates to {@link #mimeMessageToEmailBuilder(MimeMessage, Pkcs12Config)}.
 	 */
 	@NotNull
@@ -94,15 +102,25 @@ public final class EmailConverter {
 	}
 
 	/**
-	 * @param mimeMessage The MimeMessage from which to create the {@link Email}.
-	 * @param pkcs12Config Private key store for decrypting S/MIME encrypted attachments
-	 *                        (only needed when the message is encrypted rather than just signed).
+	 * Delegates to {@link #mimeMessageToEmailBuilder(MimeMessage, Pkcs12Config, boolean)}.
 	 */
 	@NotNull
 	public static EmailPopulatingBuilder mimeMessageToEmailBuilder(@NotNull final MimeMessage mimeMessage, @Nullable final Pkcs12Config pkcs12Config) {
+		return mimeMessageToEmailBuilder(mimeMessage, pkcs12Config, true);
+	}
+
+	/**
+	 * @param mimeMessage The MimeMessage from which to create the {@link Email}.
+	 * @param pkcs12Config Private key store for decrypting S/MIME encrypted attachments
+	 *                        (only needed when the message is encrypted rather than just signed).
+	 * @param attachmentData When false only the names of the attachments are retrieved but no data
+	 */
+	@NotNull
+	public static EmailPopulatingBuilder mimeMessageToEmailBuilder(@NotNull final MimeMessage mimeMessage, @Nullable final Pkcs12Config pkcs12Config,
+			boolean attachmentData) {
 		checkNonEmptyArgument(mimeMessage, "mimeMessage");
 		final EmailPopulatingBuilder builder = EmailBuilder.ignoringDefaults().startingBlank();
-		final ParsedMimeMessageComponents parsed = MimeMessageParser.parseMimeMessage(mimeMessage);
+		final ParsedMimeMessageComponents parsed = MimeMessageParser.parseMimeMessage(mimeMessage, attachmentData);
 		return decryptAttachments(buildEmailFromMimeMessage(builder, parsed), mimeMessage, pkcs12Config);
 	}
 

--- a/modules/simple-java-mail/src/main/java/org/simplejavamail/converter/internal/mimemessage/MimeMessageParser.java
+++ b/modules/simple-java-mail/src/main/java/org/simplejavamail/converter/internal/mimemessage/MimeMessageParser.java
@@ -111,9 +111,16 @@ public final class MimeMessageParser {
 	}
 
 	/**
-	 * Extracts the content of a MimeMessage recursively.
+	 * Delegates to {@link #parseMimeMessage(MimeMessage, boolean)}.
 	 */
 	public static ParsedMimeMessageComponents parseMimeMessage(@NotNull final MimeMessage mimeMessage) {
+		return parseMimeMessage(mimeMessage, true);
+	}
+
+	/**
+	 * Extracts the content of a MimeMessage recursively.
+	 */
+	public static ParsedMimeMessageComponents parseMimeMessage(@NotNull final MimeMessage mimeMessage, boolean attachmentData) {
 		final ParsedMimeMessageComponents parsedComponents = new ParsedMimeMessageComponents();
 		parsedComponents.messageId = parseMessageId(mimeMessage);
 		parsedComponents.sentDate = parseSentDate(mimeMessage);
@@ -123,12 +130,13 @@ public final class MimeMessageParser {
 		parsedComponents.bccAddresses.addAll(parseBccAddresses(mimeMessage));
 		parsedComponents.fromAddress = parseFromAddress(mimeMessage);
 		parsedComponents.replyToAddresses = parseReplyToAddresses(mimeMessage);
-		parseMimePartTree(mimeMessage, parsedComponents);
+		parseMimePartTree(mimeMessage, parsedComponents, attachmentData);
 		moveInvalidEmbeddedResourcesToAttachments(parsedComponents);
 		return parsedComponents;
 	}
 
-	private static void parseMimePartTree(@NotNull final MimePart currentPart, @NotNull final ParsedMimeMessageComponents parsedComponents) {
+	private static void parseMimePartTree(@NotNull final MimePart currentPart, @NotNull final ParsedMimeMessageComponents parsedComponents,
+			boolean attachmentData) {
 		for (final Header header : retrieveAllHeaders(currentPart)) {
 			parseHeader(header, parsedComponents);
 		}
@@ -147,10 +155,10 @@ public final class MimeMessageParser {
 		} else if (isMimeType(currentPart, "multipart/*")) {
 			final Multipart mp = parseContent(currentPart);
 			for (int i = 0, count = countBodyParts(mp); i < count; i++) {
-				parseMimePartTree(getBodyPartAtIndex(mp, i), parsedComponents);
+				parseMimePartTree(getBodyPartAtIndex(mp, i), parsedComponents, attachmentData);
 			}
 		} else {
-			final DataSource ds = createDataSource(currentPart);
+			final DataSource ds = createDataSource(currentPart, attachmentData);
 			// if the diposition is not provided, for now the part should be treated as inline (later non-embedded inline attachments are moved)
 			if (Part.ATTACHMENT.equalsIgnoreCase(disposition)) {
 				parsedComponents.attachmentList.put(parseResourceNameOrUnnamed(parseContentID(currentPart), parseFileName(currentPart)), ds);
@@ -363,16 +371,22 @@ public final class MimeMessageParser {
 	 * @return the DataSource
 	 */
 	@NotNull
-	private static DataSource createDataSource(@NotNull final MimePart part) {
+	private static DataSource createDataSource(@NotNull final MimePart part, boolean attachmentData) {
 		final DataHandler dataHandler = retrieveDataHandler(part);
 		final DataSource dataSource = dataHandler.getDataSource();
-		final String contentType = parseBaseMimeType(dataSource.getContentType());
-		final byte[] content = readContent(retrieveInputStream(dataSource));
-		final ByteArrayDataSource result = new ByteArrayDataSource(content, contentType);
-		final String dataSourceName = parseDataSourceName(part, dataSource);
 
-		result.setName(dataSourceName);
-		return result;
+		if (attachmentData) {
+			final String contentType = parseBaseMimeType(dataSource.getContentType());
+			final byte[] content = readContent(retrieveInputStream(dataSource));
+			final ByteArrayDataSource result = new ByteArrayDataSource(content, contentType);
+			final String dataSourceName = parseDataSourceName(part, dataSource);
+
+			result.setName(dataSourceName);
+			return result;
+		}
+		else {
+			return dataSource;
+		}
 	}
 
 	@SuppressWarnings("WeakerAccess")


### PR DESCRIPTION
I´d like to know of there is some way to parse a `MimeMessage` (like `EmailConverter.mimeMessageToEmail`) that does not read the contents of all attachments. I have a use case where it is useful to have the Email object but the emails have large attachments that take some time to download from the IMAP server and are not needed.
I suppose it is possible to create an Email object that reads the attachment contents only when they are requested, for example by executing the `getAttachments` function.
If this does not exist maybe I will develop it myself unless you think that is not possible for some reason I'm not seeing right now.

Thanks