### PR TITLE
Fix NoClassDefFoundError on Android < 8.0

### DIFF
--- a/modules/cli-module/src/main/java/org/simplejavamail/internal/clisupport/CliSupport.java
+++ b/modules/cli-module/src/main/java/org/simplejavamail/internal/clisupport/CliSupport.java
@@ -7,7 +7,7 @@ import org.simplejavamail.api.internal.clisupport.model.CliReceivedCommand;
 import org.simplejavamail.api.mailer.MailerFromSessionBuilder;
 import org.simplejavamail.api.mailer.MailerRegularBuilder;
 import org.simplejavamail.internal.clisupport.serialization.SerializationUtil;
-import org.simplejavamail.internal.util.MiscUtil;
+import org.simplejavamail.internal.util.FileUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
@@ -38,9 +38,9 @@ public class CliSupport {
 			if (!CLI_DATAFILE.exists()) {
 				LOGGER.info("Initial cli.data not found, writing to (one time action): {}", CLI_DATAFILE);
 				List<CliDeclaredOptionSpec> declaredOptions = generateOptionsFromBuilderApi(RELEVANT_BUILDER_ROOT_API);
-				MiscUtil.writeFileBytes(CLI_DATAFILE, SerializationUtil.serialize(declaredOptions));
+				FileUtil.writeFileBytes(CLI_DATAFILE, SerializationUtil.serialize(declaredOptions));
 			}
-			return SerializationUtil.deserialize(MiscUtil.readFileBytes(CLI_DATAFILE));
+			return SerializationUtil.deserialize(FileUtil.readFileBytes(CLI_DATAFILE));
 		} catch (IOException e) {
 			throw new CliExecutionException(ERROR_INVOKING_BUILDER_API, e);
 		}

--- a/modules/cli-module/src/main/java/org/simplejavamail/internal/clisupport/therapijavadoc/TherapiJavadocHelper.java
+++ b/modules/cli-module/src/main/java/org/simplejavamail/internal/clisupport/therapijavadoc/TherapiJavadocHelper.java
@@ -17,7 +17,7 @@ import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
 import org.simplejavamail.internal.clisupport.CliDataLocator;
 import org.simplejavamail.internal.clisupport.serialization.SerializationUtil;
-import org.simplejavamail.internal.util.MiscUtil;
+import org.simplejavamail.internal.util.FileUtil;
 
 import java.io.File;
 import java.io.IOException;
@@ -48,7 +48,7 @@ public final class TherapiJavadocHelper {
 	private static Map<String, MethodJavadoc> loadTherapiCache() {
 		if (THERAPI_DATAFILE.exists()) {
 			try {
-				return SerializationUtil.deserialize(MiscUtil.readFileBytes(THERAPI_DATAFILE));
+				return SerializationUtil.deserialize(FileUtil.readFileBytes(THERAPI_DATAFILE));
 			} catch (IOException e) {
 				throw new RuntimeException(e);
 			}
@@ -60,7 +60,7 @@ public final class TherapiJavadocHelper {
 	@TestOnly
 	public static void persistCache() {
 		try {
-			MiscUtil.writeFileBytes(THERAPI_DATAFILE, SerializationUtil.serialize(THERAPI_CACHE));
+			FileUtil.writeFileBytes(THERAPI_DATAFILE, SerializationUtil.serialize(THERAPI_CACHE));
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}

--- a/modules/core-module/src/main/java/org/simplejavamail/internal/util/FileUtil.java
+++ b/modules/core-module/src/main/java/org/simplejavamail/internal/util/FileUtil.java
@@ -1,0 +1,36 @@
+package org.simplejavamail.internal.util;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+
+import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+// FileUtil uses java.nio.file, which is not available on Android < 8.0 and will throw there a NoClassDefFoundError.
+// See https://developer.android.com/reference/java/nio/file/package-summary.
+// Therefore, keep imports of java.nio.file.* inside this class.
+public class FileUtil {
+    public static String readFileContent(@NotNull final File file) throws IOException {
+        return new String(readFileBytes(file), UTF_8);
+    }
+
+    public static byte[] readFileBytes(@NotNull final File file) throws IOException {
+        if (!file.exists()) {
+            throw new IllegalArgumentException(format("File not found: %s", file));
+        }
+        return Files.readAllBytes(file.toPath());
+    }
+
+    public static void writeFileBytes(@NotNull final File file, final byte[] bytes) throws IOException {
+        try {
+            Files.createFile(file.toPath());
+        } catch (FileAlreadyExistsException e) {
+            // ignore
+        }
+        Files.write(file.toPath(), bytes);
+    }
+}

--- a/modules/core-module/src/main/java/org/simplejavamail/internal/util/MiscUtil.java
+++ b/modules/core-module/src/main/java/org/simplejavamail/internal/util/MiscUtil.java
@@ -23,8 +23,6 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.nio.charset.Charset;
-import java.nio.file.FileAlreadyExistsException;
-import java.nio.file.Files;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -225,26 +223,6 @@ public final class MiscUtil {
 			}
 		}
 		return false;
-	}
-
-	public static String readFileContent(@NotNull final File file) throws IOException {
-		return new String(readFileBytes(file), UTF_8);
-	}
-
-	public static byte[] readFileBytes(@NotNull final File file) throws IOException {
-		if (!file.exists()) {
-			throw new IllegalArgumentException(format("File not found: %s", file));
-		}
-		return Files.readAllBytes(file.toPath());
-	}
-
-	public static void writeFileBytes(@NotNull final File file, final byte[] bytes) throws IOException {
-		try {
-			Files.createFile(file.toPath());
-		} catch (FileAlreadyExistsException e) {
-			// ignore
-		}
-		Files.write(file.toPath(), bytes);
 	}
 
 	@Nullable

--- a/modules/simple-java-mail/src/main/java/org/simplejavamail/email/internal/EmailPopulatingBuilderImpl.java
+++ b/modules/simple-java-mail/src/main/java/org/simplejavamail/email/internal/EmailPopulatingBuilderImpl.java
@@ -16,6 +16,7 @@ import org.simplejavamail.api.internal.smimesupport.model.PlainSmimeDetails;
 import org.simplejavamail.api.mailer.config.Pkcs12Config;
 import org.simplejavamail.email.EmailBuilder;
 import org.simplejavamail.internal.util.CertificationUtil;
+import org.simplejavamail.internal.util.FileUtil;
 import org.simplejavamail.internal.util.MiscUtil;
 import org.simplejavamail.internal.util.NamedDataSource;
 
@@ -642,7 +643,7 @@ public class EmailPopulatingBuilderImpl implements InternalEmailPopulatingBuilde
 	@Cli.OptionNameOverride("withPlainTextFromFile")
 	public EmailPopulatingBuilder withPlainText(@NotNull final File textFile) {
 		try {
-			return withPlainText(MiscUtil.readFileContent(textFile));
+			return withPlainText(FileUtil.readFileContent(textFile));
 		} catch (IOException e) {
 			throw new EmailException(format(ERROR_READING_FROM_FILE, textFile), e);
 		}
@@ -664,7 +665,7 @@ public class EmailPopulatingBuilderImpl implements InternalEmailPopulatingBuilde
 	@Cli.OptionNameOverride("prependTextFromFile")
 	public EmailPopulatingBuilder prependText(@NotNull final File textFile) {
 		try {
-			return prependText(MiscUtil.readFileContent(textFile));
+			return prependText(FileUtil.readFileContent(textFile));
 		} catch (IOException e) {
 			throw new EmailException(format(ERROR_READING_FROM_FILE, textFile), e);
 		}
@@ -686,7 +687,7 @@ public class EmailPopulatingBuilderImpl implements InternalEmailPopulatingBuilde
 	@Cli.OptionNameOverride("appendTextFromFile")
 	public EmailPopulatingBuilder appendText(@NotNull final File textFile) {
 		try {
-			return appendText(MiscUtil.readFileContent(textFile));
+			return appendText(FileUtil.readFileContent(textFile));
 		} catch (IOException e) {
 			throw new EmailException(format(ERROR_READING_FROM_FILE, textFile), e);
 		}
@@ -708,7 +709,7 @@ public class EmailPopulatingBuilderImpl implements InternalEmailPopulatingBuilde
 	@Cli.OptionNameOverride("withHTMLTextFromFile")
 	public EmailPopulatingBuilder withHTMLText(@NotNull final File textHTMLFile) {
 		try {
-			return withHTMLText(MiscUtil.readFileContent(textHTMLFile));
+			return withHTMLText(FileUtil.readFileContent(textHTMLFile));
 		} catch (IOException e) {
 			throw new EmailException(format(ERROR_READING_FROM_FILE, textHTMLFile), e);
 		}
@@ -730,7 +731,7 @@ public class EmailPopulatingBuilderImpl implements InternalEmailPopulatingBuilde
 	@Cli.OptionNameOverride("prependTextHTMLFromFile")
 	public EmailPopulatingBuilder prependTextHTML(@NotNull final File textHTMLFile) {
 		try {
-			return prependTextHTML(MiscUtil.readFileContent(textHTMLFile));
+			return prependTextHTML(FileUtil.readFileContent(textHTMLFile));
 		} catch (IOException e) {
 			throw new EmailException(format(ERROR_READING_FROM_FILE, textHTMLFile), e);
 		}
@@ -752,7 +753,7 @@ public class EmailPopulatingBuilderImpl implements InternalEmailPopulatingBuilde
 	@Cli.OptionNameOverride("appendTextHTMLFromFile")
 	public EmailPopulatingBuilder appendTextHTML(@NotNull final File textHTMLFile) {
 		try {
-			return appendTextHTML(MiscUtil.readFileContent(textHTMLFile));
+			return appendTextHTML(FileUtil.readFileContent(textHTMLFile));
 		} catch (IOException e) {
 			throw new EmailException(format(ERROR_READING_FROM_FILE, textHTMLFile), e);
 		}

--- a/modules/simple-java-mail/src/test/java/org/simplejavamail/internal/util/MiscUtilTest.java
+++ b/modules/simple-java-mail/src/test/java/org/simplejavamail/internal/util/MiscUtilTest.java
@@ -162,22 +162,22 @@ public class MiscUtilTest {
 	@Test
 	public void testReadFileContent()
 			throws IOException {
-		assertThatThrownBy(() -> MiscUtil.readFileContent(new File("moo")))
+		assertThatThrownBy(() -> FileUtil.readFileContent(new File("moo")))
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessageContaining("File not found: moo");
 
-		assertThat(MiscUtil.readFileContent(new File("src/test/resources/ignore.properties")))
+		assertThat(FileUtil.readFileContent(new File("src/test/resources/ignore.properties")))
 				.contains("simplejavamail.defaults.bcc.address=moo");
 	}
 
 	@Test
 	public void testWriteFileContent()
 			throws IOException {
-		MiscUtil.writeFileBytes(new File("target/test.file"), "This is a test".getBytes());
+		FileUtil.writeFileBytes(new File("target/test.file"), "This is a test".getBytes());
 
-		assertThat(MiscUtil.readFileBytes(new File("target/test.file")))
+		assertThat(FileUtil.readFileBytes(new File("target/test.file")))
 				.isEqualTo("This is a test".getBytes());
-		assertThat(MiscUtil.readFileContent(new File("target/test.file")))
+		assertThat(FileUtil.readFileContent(new File("target/test.file")))
 				.isEqualTo("This is a test");
 	}
 


### PR DESCRIPTION
`java.nio.file` is only available starting at android API level 26 (= Android 8.0), see https://developer.android.com/reference/java/nio/file/package-summary.
According to Google, 17,3% of all android phones currently (December 2021) in use are below Android version 8.0.
Note that [java.nio.channels](https://developer.android.com/reference/java/nio/channels/package-summary) and [java.nio.charsets](https://developer.android.com/reference/java/nio/charset/package-summary) are available since Android API level 1 (= Android 1.0).

Moving the usages of java.io.file into an own class omits a `java.lang.NoClassDefFoundError` during runtime. Previously this error gets thrown when MicsUtil was first loaded from classpath (e.g. when using MiscUtil.valueNullOrEmpty() in Email.java). Now with this PR all java.nio.file imports happen only in one file, which is not loaded during runtime when not using the CLI (which you most probably don't do on Android).