### PR TITLE
Adjust dependencies and make Java 9+ friendly

### DIFF
--- a/modules/core-module/pom.xml
+++ b/modules/core-module/pom.xml
@@ -34,12 +34,6 @@
             <artifactId>jakarta.activation</artifactId>
             <version>2.0.1</version>
         </dependency>
-        <!-- java 9+ compatibility, these modules are not shipped anymore -->
-        <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
-            <version>2.3.2</version>
-        </dependency>
 
         <dependency><!-- email validation framework -->
             <groupId>com.sanctionco.jmail</groupId>

--- a/modules/core-module/pom.xml
+++ b/modules/core-module/pom.xml
@@ -40,11 +40,6 @@
             <artifactId>jakarta.xml.bind-api</artifactId>
             <version>2.3.2</version>
         </dependency>
-        <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-            <version>1.3.5</version>
-        </dependency>
 
         <dependency><!-- email validation framework -->
             <groupId>com.sanctionco.jmail</groupId>

--- a/modules/core-test-module/pom.xml
+++ b/modules/core-test-module/pom.xml
@@ -44,5 +44,11 @@
             <artifactId>assertj-core</artifactId>
             <version>3.21.0</version>
         </dependency>
+        <!-- java 9+ compatibility, these modules are not shipped anymore -->
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>3.0.1</version>
+        </dependency>
     </dependencies>
 </project>

--- a/modules/core-test-module/src/main/java/demo/DemoAppBase.java
+++ b/modules/core-test-module/src/main/java/demo/DemoAppBase.java
@@ -8,7 +8,7 @@ import testutil.ConfigLoaderTestHelper;
 import testutil.ImplLoader;
 import testutil.ModuleLoaderTestHelper;
 
-import static javax.xml.bind.DatatypeConverter.parseBase64Binary;
+import static jakarta.xml.bind.DatatypeConverter.parseBase64Binary;
 
 public class DemoAppBase {
 

--- a/modules/simple-java-mail/pom.xml
+++ b/modules/simple-java-mail/pom.xml
@@ -83,6 +83,14 @@
             <version>6.0.1</version>
             <scope>test</scope>
         </dependency>
+        <!-- required for java 9+ compatibility with assertj-assertions-generator-maven-plugin, which uses javax.annotation.Generated -->
+        <!-- see https://github.com/assertj/assertj-assertions-generator-maven-plugin/issues/93 -->
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <version>1.3.5</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/modules/simple-java-mail/src/test/java/org/simplejavamail/email/internal/EmailPopulatingBuilderUsingDefaultsFromPropertyFileTest.java
+++ b/modules/simple-java-mail/src/test/java/org/simplejavamail/email/internal/EmailPopulatingBuilderUsingDefaultsFromPropertyFileTest.java
@@ -16,7 +16,7 @@ import java.nio.charset.Charset;
 import java.util.Properties;
 
 import static demo.ResourceFolderHelper.determineResourceFolder;
-import static javax.xml.bind.DatatypeConverter.parseBase64Binary;
+import static jakarta.xml.bind.DatatypeConverter.parseBase64Binary;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class EmailPopulatingBuilderUsingDefaultsFromPropertyFileTest {

--- a/modules/simple-java-mail/src/test/java/org/simplejavamail/mailer/MailerTest.java
+++ b/modules/simple-java-mail/src/test/java/org/simplejavamail/mailer/MailerTest.java
@@ -30,8 +30,8 @@ import java.util.Properties;
 import java.util.UUID;
 
 import static demo.ResourceFolderHelper.determineResourceFolder;
+import static jakarta.xml.bind.DatatypeConverter.parseBase64Binary;
 import static java.util.Calendar.APRIL;
-import static javax.xml.bind.DatatypeConverter.parseBase64Binary;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;

--- a/modules/simple-java-mail/src/test/java/testutil/EmailHelper.java
+++ b/modules/simple-java-mail/src/test/java/testutil/EmailHelper.java
@@ -25,11 +25,11 @@ import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 
+import static jakarta.xml.bind.DatatypeConverter.parseBase64Binary;
 import static java.util.Calendar.SEPTEMBER;
 import static java.util.Optional.ofNullable;
 import static java.util.UUID.randomUUID;
 import static java.util.concurrent.Executors.newSingleThreadExecutor;
-import static javax.xml.bind.DatatypeConverter.parseBase64Binary;
 import static org.simplejavamail.api.mailer.config.LoadBalancingStrategy.ROUND_ROBIN;
 import static org.simplejavamail.converter.EmailConverter.emlToEmailBuilder;
 import static org.simplejavamail.converter.EmailConverter.outlookMsgToEmailBuilder;


### PR DESCRIPTION
- Make jakarta.annotation-api a test dependency since it is only required for assertj-assertions-generator-maven-plugin.
- Make jakarta.xml.bind-api a test dependency and switch to newer version in jakarta namespace since it is only used in test code.