### PR TITLE
Could org.simplejavamail:authenticated-socks-module:7.1.0 drop off redundant dependencies?

### DIFF
--- a/modules/authenticated-socks-module/pom.xml
+++ b/modules/authenticated-socks-module/pom.xml
@@ -27,6 +27,19 @@
             <groupId>org.simplejavamail</groupId>
             <artifactId>core-module</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.github.bbottema</groupId>
+                    <artifactId>jetbrains-runtime-annotations</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.github.bbottema</groupId>
+            <artifactId>jetbrains-runtime-annotations</artifactId>
+            <version>1.0.1</version>
+            <type>jar</type>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/78527112/163953574-6dede7a4-fa4c-465b-a603-46b335b123b9.png)
This figure presents the dependency tree between multiple modules in **_maven-master-project_**. As shown in this figure, Library **_com.github.bbottema:jetbrains-runtime-annotations_** in 
**__
        <module>core-module</module>
        <module>core-test-module</module>
        <module>batch-module</module>
        <module>authenticated-socks-module</module>
        <module>outlook-module</module>
        <module>dkim-module</module>
        <module>smime-module</module>
        <module>simple-java-mail</module>
        <module>spring-module</module>
        <module>cli-module</module>
        <module>jacoco-aggregator-module</module>
__**
is inherited from their parent module. However, it is not used by **_authenticated-socks-module_**. We can perform refactoring operations in the pom, by removing such redundant dependencies in **_authenticated-socks-module_**.

Specifically, the scope of **_com.github.bbottema:jetbrains-runtime-annotations_** in **_authenticated-socks-module_** can be changed from **_compile_** to **_provided_**. The revisions in the pom are described as follows:
![image](https://user-images.githubusercontent.com/78527112/163954227-5912dd66-0b94-4680-b655-25c9f46ef00e.png)
