### PR TITLE
Upgrade jmail version to 1.4.1

### DIFF
--- a/modules/core-module/pom.xml
+++ b/modules/core-module/pom.xml
@@ -38,7 +38,7 @@
         <dependency><!-- email validation framework -->
             <groupId>com.sanctionco.jmail</groupId>
             <artifactId>jmail</artifactId>
-            <version>1.2.1</version>
+            <version>1.4.1</version>
         </dependency>
 
         <dependency><!-- Annotation processor -->


### PR DESCRIPTION
Hi @bbottema,

Thanks a lot for using JMail! I noticed (when looking at download statistics in Maven Central) that the version that you are using is a bit outdated at this point, so opening this to upgrade the version. The latest version includes a few bug fixes for email addresses that were incorrectly validated, as well as some other enhancements.

Full changes here: https://github.com/RohanNagar/jmail/releases