### PR TITLE
 fixed exception handling for acquireTransport

### DIFF
--- a/modules/batch-module/src/main/java/org/simplejavamail/internal/batchsupport/BatchException.java
+++ b/modules/batch-module/src/main/java/org/simplejavamail/internal/batchsupport/BatchException.java
@@ -2,7 +2,7 @@ package org.simplejavamail.internal.batchsupport;
 
 class BatchException extends RuntimeException {
 
-	static final String ERROR_ACQUIRING_KEYED_POOLABLE = "Was unable to obtain a poolable object for key:\t%n%s";
+	static final String ERROR_ACQUIRING_KEYED_POOLABLE = "Was unable to obtain a poolable object for key or exception during allocate:\t%n%s";
 
 	BatchException(final String msg, final Throwable cause) {
 		super(msg, cause);

--- a/modules/batch-module/src/main/java/org/simplejavamail/internal/batchsupport/BatchSupport.java
+++ b/modules/batch-module/src/main/java/org/simplejavamail/internal/batchsupport/BatchSupport.java
@@ -111,8 +111,8 @@ public class BatchSupport implements BatchModule {
 			return stickySession
 					? smtpConnectionPool.claimResourceFromPool(new ResourceClusterAndPoolKey<>(clusterKey, session))
 					: smtpConnectionPool.claimResourceFromCluster(clusterKey);
-		} catch (InterruptedException e) {
-			throw new BatchException(format(ERROR_ACQUIRING_KEYED_POOLABLE, session), e);
+		} catch (Exception e) {
+			return null;
 		}
 	}
 


### PR DESCRIPTION
Hi, 
Please review these changes, below are the changes 
1. returning null as,  Optional.ofNullable() will skip the next mapping and throw an exception if the value is null. 
2. apart from `InterruptedException`, other exceptions can also occure hence used generic Exception. ( for example `allocate` can throw an exception)

thanks, 
