### PR TITLE
Trim whitespace in encoder values

### DIFF
--- a/modules/core-module/src/main/java/org/simplejavamail/api/email/ContentTransferEncoding.java
+++ b/modules/core-module/src/main/java/org/simplejavamail/api/email/ContentTransferEncoding.java
@@ -32,10 +32,10 @@ public enum ContentTransferEncoding {
 
 	public static ContentTransferEncoding byEncoder(@NotNull final String encoder) {
 		try {
-			return ContentTransferEncoding.valueOf(encoder.replaceAll("-", "_").toUpperCase());
+			return ContentTransferEncoding.valueOf(encoder.trim().replaceAll("-", "_").toUpperCase());
 		} catch (IllegalArgumentException e) {
 			return Arrays.stream(values())
-					.filter(c -> c.encoder.equalsIgnoreCase(encoder.replaceAll("_", "-")))
+					.filter(c -> c.encoder.equalsIgnoreCase(encoder.trim().replaceAll("_", "-")))
 					.findFirst()
 					.orElseThrow(() -> new IllegalArgumentException("unknown content transfer encoder: " + encoder));
 		}

--- a/modules/simple-java-mail/src/test/java/org/simplejavamail/api/email/ContentTransferEncodingTest.java
+++ b/modules/simple-java-mail/src/test/java/org/simplejavamail/api/email/ContentTransferEncodingTest.java
@@ -13,6 +13,7 @@ public class ContentTransferEncodingTest {
         assertThat(ContentTransferEncoding.byEncoder("B")).isEqualTo(ContentTransferEncoding.B);
         assertThat(ContentTransferEncoding.byEncoder("b")).isEqualTo(ContentTransferEncoding.B);
         assertThat(ContentTransferEncoding.byEncoder("8bit")).isEqualTo(ContentTransferEncoding.BIT8);
+        assertThat(ContentTransferEncoding.byEncoder("7bit        ")).isEqualTo(ContentTransferEncoding.BIT7);
         assertThat(ContentTransferEncoding.byEncoder("x-uuencode")).isEqualTo(ContentTransferEncoding.X_UU);
         assertThat(ContentTransferEncoding.byEncoder("x_uuencode")).isEqualTo(ContentTransferEncoding.X_UU);
         assertThat(ContentTransferEncoding.byEncoder("QUOTED-PRINTABLE")).isEqualTo(ContentTransferEncoding.QUOTED_PRINTABLE);


### PR DESCRIPTION
Added `trim()` method to clean up input encoder values before processing in `ContentTransferEncoding.java`. Updated test cases in `ContentTransferEncodingTest.java` to cover the new behavior.