### PR TITLE
Fixed flaky test case in EmailTest.java

### DIFF
--- a/modules/simple-java-mail/src/main/java/org/simplejavamail/email/internal/EmailPopulatingBuilderImpl.java
+++ b/modules/simple-java-mail/src/main/java/org/simplejavamail/email/internal/EmailPopulatingBuilderImpl.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -246,7 +247,7 @@ public class EmailPopulatingBuilderImpl implements InternalEmailPopulatingBuilde
 	 * @see EmailStartingBuilder#replyingTo(MimeMessage, boolean, String)
 	 */
 	@NotNull
-	private final Map<String, Collection<String>> headers = new HashMap<>();
+	private final Map<String, Collection<String>> headers = new LinkedHashMap<>();
 
 	/**
 	 * @see #signWithDomainKey(DkimConfig)
@@ -2449,7 +2450,7 @@ public class EmailPopulatingBuilderImpl implements InternalEmailPopulatingBuilde
 	@NotNull
 	@Override
 	public Map<String, Collection<String>> getHeaders() {
-		return new HashMap<>(headers);
+		return new LinkedHashMap<>(headers);
 	}
 	
 	/**


### PR DESCRIPTION
Fixed flaky test case in the following class: `org.simplejavamail.api.email.EmailTest`

Assertion called in: `EmailTest#testToStringFull`

### POINT OF FAILURE
In `EmailPopulatingBuilderImpl` class, headers was of type `HashMap`. HashMap being unordered, can give non-deterministic results for `toString()` method when run on different jvms. 
Observed failure was:
```
expectedEmailString ~ "...headers={dummyHeader1=[dummyHeaderValue1], dummyHeader2=[dummyHeaderValue2]}..."
actualEmailString ~ "...headers={dummyHeader2=[dummyHeaderValue2], dummyHeader1=[dummyHeaderValue1]}..."
```

### FIX
Changed the type of `headers` to `LinkedHashMap` as it retrieves the order of insertion in the Map, guaranteeing consistent `toString()` output.

### Fixed using NonDex
Suggested command to check flaky tests :
> mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex

For the particular test class:
```sh
mvn -pl ./modules/simple-java-mail edu.illinois:nondex-maven-plugin:2.1.7:nondex \
-Dmode=ONE \
-DnondexRuns=5  \
-Dtest=org.simplejavamail.api.email.EmailTest#testToStringFull \
-Dossindex.skip=true -Dspotbugs.skip=true \
-Dmaven.javadoc.skip=true -Denforcer.skip=true \
-Djacoco.skip=true -Dlicense.skip=true
```
For more information: https://github.com/TestingResearchIllinois/NonDex