### PR TITLE
[Authenticated SOCKS module] Let the OS allocate an ephemeral port

### DIFF
--- a/modules/authenticated-socks-module/src/main/java/org/simplejavamail/internal/authenticatedsockssupport/socks5server/AnonymousSocks5ServerImpl.java
+++ b/modules/authenticated-socks-module/src/main/java/org/simplejavamail/internal/authenticatedsockssupport/socks5server/AnonymousSocks5ServerImpl.java
@@ -1,17 +1,17 @@
 package org.simplejavamail.internal.authenticatedsockssupport.socks5server;
 
-import org.simplejavamail.api.internal.authenticatedsockssupport.common.Socks5Bridge;
-import org.simplejavamail.api.internal.authenticatedsockssupport.socks5server.AnonymousSocks5Server;
-import org.simplejavamail.internal.authenticatedsockssupport.common.SocksException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+
+import org.simplejavamail.api.internal.authenticatedsockssupport.common.Socks5Bridge;
+import org.simplejavamail.api.internal.authenticatedsockssupport.socks5server.AnonymousSocks5Server;
+import org.simplejavamail.internal.authenticatedsockssupport.common.SocksException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @see AnonymousSocks5Server
@@ -101,5 +101,13 @@ public class AnonymousSocks5ServerImpl implements AnonymousSocks5Server {
 	@Override
 	public boolean isRunning() {
 		return running;
+	}
+
+	@Override
+	public int getLocalPort() {
+		if (serverSocket == null) {
+			return -1;
+		}
+		return serverSocket.getLocalPort();
 	}
 }

--- a/modules/core-module/src/main/java/org/simplejavamail/api/internal/authenticatedsockssupport/socks5server/AnonymousSocks5Server.java
+++ b/modules/core-module/src/main/java/org/simplejavamail/api/internal/authenticatedsockssupport/socks5server/AnonymousSocks5Server.java
@@ -17,4 +17,12 @@ public interface AnonymousSocks5Server extends Runnable {
 	boolean isStopping();
 	
 	boolean isRunning();
+
+	/**
+	 * Returns the port number on which this server is listening.
+	 *
+	 * @return  the port number to which this server is listening or
+	 *          -1 if the server is not started yet.
+	 */
+	int getLocalPort();
 }


### PR DESCRIPTION
It is already possible to let the OS allocate an ephemeral port when starting the SOCKS proxy server with port = 0.

This very simple PR allows to retrieve the allocated port after the server is started by introducing a getter :

```java
AnonymousSocks5Server s = new AnonymousSocks5ServerImpl(new AuthenticatingSocks5Bridge(socksProxyConfig), 0);
// Get SOCKS server port
int port = s.getLocalPort();
```

So it can be used in other projects.