### PR TITLE
feat: support manually setting content id for attachment

### DIFF
--- a/modules/core-module/src/main/java/org/simplejavamail/api/email/AttachmentResource.java
+++ b/modules/core-module/src/main/java/org/simplejavamail/api/email/AttachmentResource.java
@@ -27,40 +27,42 @@ public class AttachmentResource implements Serializable {
 	private static final long serialVersionUID = 1234567L;
 
 	/**
-	 * @see #AttachmentResource(String, DataSource, String)
+	 * @see #AttachmentResource(String, String, DataSource, String)
 	 */
 	private final String name;
 
+	private final String contentId;
+
 	/**
-	 * @see #AttachmentResource(String, DataSource, String)
+	 * @see #AttachmentResource(String, String, DataSource, String)
 	 */
 	// data source is not serializable, so transient (Kryo can do it though, see SerializationUtil in the OutlookModule)
 	private transient final DataSource dataSource;
 
 	/**
-	 * @see #AttachmentResource(String, DataSource, String)
+	 * @see #AttachmentResource(String, String, DataSource, String)
 	 */
 	@Nullable
 	private final String description;
 
 	/**
-	 * @see #AttachmentResource(String, DataSource, String)
+	 * @see #AttachmentResource(String, String, DataSource, String)
 	 */
 	@Nullable
 	private final ContentTransferEncoding contentTransferEncoding;
 
 	/**
-	 * Delegates to {@link AttachmentResource#AttachmentResource(String, DataSource, String, ContentTransferEncoding)} with null-description and no forced content transfer encoding
+	 * Delegates to {@link AttachmentResource#AttachmentResource(String, String, DataSource, String, ContentTransferEncoding)} with null-description and no forced content transfer encoding
 	 */
-	public AttachmentResource(@Nullable final String name, @NotNull final DataSource dataSource) {
-		this(name, dataSource, null, null);
+	public AttachmentResource(@Nullable final String name, final String contentId, @NotNull final DataSource dataSource) {
+		this(name, contentId, dataSource, null, null);
 	}
 
 	/**
-	 * Delegates to {@link AttachmentResource#AttachmentResource(String, DataSource, String, ContentTransferEncoding)} with no forced content transfer encoding
+	 * Delegates to {@link AttachmentResource#AttachmentResource(String, String, DataSource, String, ContentTransferEncoding)} with no forced content transfer encoding
 	 */
-	public AttachmentResource(@Nullable final String name, @NotNull final DataSource dataSource, @Nullable final String description) {
-		this(name, dataSource, description, null);
+	public AttachmentResource(@Nullable final String name, final String contentId, @NotNull final DataSource dataSource, @Nullable final String description) {
+		this(name, contentId, dataSource, description, null);
 	}
 
 	/**
@@ -68,14 +70,16 @@ public class AttachmentResource implements Serializable {
 	 *
 	 * @param name                    The name of the attachment which can be a simple name, a filename or a named embedded image (eg. &lt;cid:footer&gt;). Leave
 	 *                                <code>null</code> to fall back on {@link DataSource#getName()}.
+	 * @param contentId               The content id of the attachment. Leave code null if you do not want to set a custom content id.
 	 * @param dataSource              The attachment data. If no name was provided, the name of this datasource is used if provided.
 	 * @param description             An optional description that will find its way in the MimeMEssage with the Content-Description header. This is rarely needed.
 	 * @param contentTransferEncoding An optional encoder option to force the data encoding while in MimeMessage/EML format.
 	 *
 	 * @see DataSource
 	 */
-	public AttachmentResource(@Nullable final String name, @NotNull final DataSource dataSource, @Nullable final String description, @Nullable final ContentTransferEncoding contentTransferEncoding) {
+	public AttachmentResource(@Nullable final String name, final String contentId, @NotNull final DataSource dataSource, @Nullable final String description, @Nullable final ContentTransferEncoding contentTransferEncoding) {
 		this.name = name;
+		this.contentId = contentId;
 		this.dataSource = checkNonEmptyArgument(dataSource, "dataSource");
 		this.description = description;
 		this.contentTransferEncoding = contentTransferEncoding;
@@ -124,7 +128,7 @@ public class AttachmentResource implements Serializable {
 	}
 
 	/**
-	 * @see #AttachmentResource(String, DataSource, String)
+	 * @see #AttachmentResource(String, String, DataSource, String)
 	 */
 	@NotNull
 	public DataSource getDataSource() {
@@ -132,7 +136,7 @@ public class AttachmentResource implements Serializable {
 	}
 
 	/**
-	 * @see #AttachmentResource(String, DataSource, String)
+	 * @see #AttachmentResource(String, String, DataSource, String)
 	 */
 	@Nullable
 	public String getName() {
@@ -140,7 +144,15 @@ public class AttachmentResource implements Serializable {
 	}
 
 	/**
-	 * @see #AttachmentResource(String, DataSource, String)
+	 * @see #AttachmentResource(String, String, DataSource, String)
+	 */
+	@Nullable
+	public String getContentId() {
+		return contentId;
+	}
+
+	/**
+	 * @see #AttachmentResource(String, String, DataSource, String)
 	 */
 	@Nullable
 	public String getDescription() {
@@ -148,7 +160,7 @@ public class AttachmentResource implements Serializable {
 	}
 
 	/**
-	 * @see #AttachmentResource(String, DataSource, String)
+	 * @see #AttachmentResource(String, String, DataSource, String)
 	 */
 	@Nullable
 	public ContentTransferEncoding getContentTransferEncoding() {
@@ -177,6 +189,7 @@ public class AttachmentResource implements Serializable {
 	public String toString() {
 		return "AttachmentResource{" +
 				"\n\t\tname='" + name + "'" +
+				",\n\t\tcontentId='" + contentId + "'" +
 				",\n\t\tdataSource.name=" + dataSource.getName() +
 				",\n\t\tdataSource.getContentType=" + dataSource.getContentType() +
 				",\n\t\tdescription=" + (description != null ? "'" + description + "'" : "null") +

--- a/modules/core-module/src/main/java/org/simplejavamail/api/email/EmailPopulatingBuilder.java
+++ b/modules/core-module/src/main/java/org/simplejavamail/api/email/EmailPopulatingBuilder.java
@@ -1162,9 +1162,19 @@ public interface EmailPopulatingBuilder {
 	EmailPopulatingBuilder withAttachment(@Nullable String name, byte@NotNull[] data, @NotNull String mimetype);
 
 	/**
+	 * Delegates to {@link #withAttachment(String, String, byte[], String, String, ContentTransferEncoding)} with null-description, no forced content transfer encoding and with content id.
+	 */
+	EmailPopulatingBuilder withAttachment(@Nullable String name, @NotNull String contentId, byte@NotNull[] data, @NotNull String mimetype);
+
+	/**
 	 * Delegates to {@link #withAttachment(String, byte[], String, String, ContentTransferEncoding)} with no forced content transfer encoding.
 	 */
 	EmailPopulatingBuilder withAttachment(@Nullable String name, byte@NotNull[] data, @NotNull String mimetype, @Nullable String description);
+
+	/**
+	 * Delegates to {@link #withAttachment(String, String, byte[], String, String, ContentTransferEncoding)} with no forced content transfer encoding and forced content id.
+	 */
+	EmailPopulatingBuilder withAttachment(@Nullable String name, @NotNull String contentId, byte@NotNull[] data, @NotNull String mimetype, @Nullable String description);
 
 	/**
 	 * Delegates to {@link #withAttachment(String, DataSource)}, with a named {@link ByteArrayDataSource} created using the provided name, data and mimetype.
@@ -1182,6 +1192,22 @@ public interface EmailPopulatingBuilder {
 	EmailPopulatingBuilder withAttachment(@Nullable String name, byte@NotNull[] data, @NotNull String mimetype, @Nullable String description, @Nullable ContentTransferEncoding contentTransferEncoding);
 
 	/**
+	 * Delegates to {@link #withAttachment(String, String, DataSource)}, with a named {@link ByteArrayDataSource} created using the provided name, content id and data and mimetype.
+	 *
+	 * @param name                    Optional name of the attachment (e.g. 'filename.ext'). If omitted, the internal name of the datasource is used. If that too is empty, a name will be generated
+	 *                                using {@link java.util.UUID}.
+	 * @param contentId               The attachment content ID.
+	 * @param data                    The binary data of the attachment.
+	 * @param mimetype                The content type of the given data (e.g. "plain/text", "image/gif" or "application/pdf").
+	 * @param description             An optional description that will find its way in the MimeMEssage with the Content-Description header. This is rarely needed.
+	 * @param contentTransferEncoding An optional encoder option to force the data encoding while in MimeMessage/EML format.
+	 *
+	 * @see #withAttachment(String, DataSource, String, ContentTransferEncoding)
+	 * @see #withAttachments(List)
+	 */
+	EmailPopulatingBuilder withAttachment(@Nullable String name, @NotNull String contentId, byte@NotNull[] data, @NotNull String mimetype, @Nullable String description, @Nullable ContentTransferEncoding contentTransferEncoding);
+
+	/**
 	 * Delegates to {@link #withAttachment(String, DataSource, String, ContentTransferEncoding)} with null-description and no forced content transfer encoding.
 	 *
 	 * @param name                    Optional name of the attachment (e.g. 'filename.ext'). If omitted, the internal name of the datasource is used. If that too is empty, a name will be generated
@@ -1189,6 +1215,16 @@ public interface EmailPopulatingBuilder {
 	 * @param filedata                The attachment data.
 	 */
 	EmailPopulatingBuilder withAttachment(@Nullable String name, @NotNull DataSource filedata);
+
+	/**
+	 * Delegates to {@link #withAttachment(String, String, DataSource, String, ContentTransferEncoding)} with null-description and no forced content transfer encoding.
+	 *
+	 * @param name                    Optional name of the attachment (e.g. 'filename.ext'). If omitted, the internal name of the datasource is used. If that too is empty, a name will be generated
+	 *                                using {@link java.util.UUID}.
+	 * @param contentId               The attachment content ID.
+	 * @param filedata                The attachment data.
+	 */
+	EmailPopulatingBuilder withAttachment(@Nullable String name, @NotNull String contentId, @NotNull DataSource filedata);
 
 	/**
 	 * Delegates to {@link #withAttachment(String, DataSource, String, ContentTransferEncoding)} with no forced content transfer encoding.
@@ -1200,6 +1236,17 @@ public interface EmailPopulatingBuilder {
 	 */
 	@Cli.OptionNameOverride("withDescribedAttachment")
 	EmailPopulatingBuilder withAttachment(@Nullable String name, @NotNull DataSource filedata, @Nullable final String description);
+
+	/**
+	 * Delegates to {@link #withAttachment(String, DataSource, String, ContentTransferEncoding)} with no forced content transfer encoding.
+	 *
+	 * @param name                    Optional name of the attachment (e.g. 'filename.ext'). If omitted, the internal name of the datasource is used. If that too is empty, a name will be generated
+	 *                                using {@link java.util.UUID}.
+	 * @param contentId               The attachment content ID.
+	 * @param filedata                The attachment data.
+	 * @param description             An optional description that will find its way in the MimeMEssage with the Content-Description header. This is rarely needed.
+	 */
+	EmailPopulatingBuilder withAttachment(@Nullable final String name, @NotNull final String contentId, @NotNull final DataSource filedata, @Nullable final String description);
 
 	/**
 	 * Adds an attachment to the email message, which will be shown in the email client as seperate files available for download or inline display if the client supports it (for example, most browsers
@@ -1218,6 +1265,26 @@ public interface EmailPopulatingBuilder {
 	 */
 	@Cli.OptionNameOverride("withEncodedDescribedAttachment")
 	EmailPopulatingBuilder withAttachment(@Nullable String name, @NotNull DataSource filedata, @Nullable final String description, @Nullable final ContentTransferEncoding contentTransferEncoding);
+
+
+	/**
+	 * Adds an attachment to the email message, which will be shown in the email client as seperate files available for download or inline display if the client supports it (for example, most browsers
+	 * these days display PDF's in a popup).
+	 * <p>
+	 * <strong>Note</strong>: for embedding images instead of attaching them for download, refer to {@link #withEmbeddedImage(String, DataSource)} instead.
+	 *
+	 * @param name                    Optional name of the attachment (e.g. 'filename.ext'). If omitted, the internal name of the datasource is used. If that too is empty, a name will be generated
+	 *                                using {@link java.util.UUID}.
+	 * @param contentId				  The attachment content ID.
+	 * @param filedata                The attachment data.
+	 * @param description             An optional description that will find its way in the MimeMEssage with the Content-Description header. This is rarely needed.
+	 * @param contentTransferEncoding An optional encoder option to force the data encoding while in MimeMessage/EML format.
+	 *
+	 * @see #withAttachment(String, DataSource, String, ContentTransferEncoding)
+	 * @see #withAttachments(List)
+	 */
+	@Cli.OptionNameOverride("withEncodedDescribedAttachment")
+	EmailPopulatingBuilder withAttachment(@Nullable String name, @NotNull final String contentId, @NotNull DataSource filedata, @Nullable final String description, @Nullable final ContentTransferEncoding contentTransferEncoding);
 
 	/**
 	 * Delegates to {@link #withAttachment(String, DataSource)} for each attachment.

--- a/modules/simple-java-mail/src/main/java/org/simplejavamail/converter/internal/mimemessage/MimeMessageHelper.java
+++ b/modules/simple-java-mail/src/main/java/org/simplejavamail/converter/internal/mimemessage/MimeMessageHelper.java
@@ -257,7 +257,7 @@ public class MimeMessageHelper {
 		final BodyPart attachmentPart = new MimeBodyPart();
 		// setting headers isn't working nicely using the javax mail API, so let's do that manually
 		final String fileName = determineResourceName(attachmentResource, dispositionType, false, false);
-		final String contentID = determineResourceName(attachmentResource, dispositionType, true, true);
+		final String contentID = determineResourceContentId(attachmentResource, dispositionType);
 		attachmentPart.setDataHandler(new DataHandler(new NamedDataSource(fileName, attachmentResource.getDataSource())));
 		attachmentPart.setFileName(fileName);
 		final String contentType = attachmentResource.getDataSource().getContentType();
@@ -301,6 +301,14 @@ public class MimeMessageHelper {
 			resourceName = possiblyAddExtension(datasourceName, resourceName);
 		}
 		return encodeResourceName ? MiscUtil.encodeText(resourceName) : resourceName;
+	}
+
+	private static String determineResourceContentId(final AttachmentResource attachmentResource, String dispositionType) {
+		if (dispositionType.equals(Part.ATTACHMENT) && attachmentResource.getContentId() != null) {
+			return attachmentResource.getContentId();
+		} else {
+			return determineResourceName(attachmentResource, dispositionType, true, true);
+		}
 	}
 
 	@NotNull

--- a/modules/simple-java-mail/src/main/java/org/simplejavamail/email/internal/EmailPopulatingBuilderImpl.java
+++ b/modules/simple-java-mail/src/main/java/org/simplejavamail/email/internal/EmailPopulatingBuilderImpl.java
@@ -1666,7 +1666,7 @@ public class EmailPopulatingBuilderImpl implements InternalEmailPopulatingBuilde
 		if (valueNullOrEmpty(name) && valueNullOrEmpty(imagedata.getName())) {
 			throw new EmailException(NAME_MISSING_FOR_EMBEDDED_IMAGE);
 		}
-		embeddedImages.add(new AttachmentResource(name, imagedata, null));
+		embeddedImages.add(new AttachmentResource(name, null, imagedata, null));
 		return this;
 	}
 	
@@ -1742,6 +1742,13 @@ public class EmailPopulatingBuilderImpl implements InternalEmailPopulatingBuilde
 	public EmailPopulatingBuilder withAttachment(@Nullable final String name, final byte@NotNull[] data, @NotNull final String mimetype) {
 		return withAttachment(name, data, mimetype, null, null);
 	}
+	/**
+	 * @see EmailPopulatingBuilder#withAttachment(String, String, byte[], String)
+	 */
+	@Override
+	public EmailPopulatingBuilder withAttachment(@Nullable final String name, @NotNull final String contentId, final byte@NotNull[] data, @NotNull final String mimetype) {
+		return withAttachment(name, contentId, data, mimetype, null, null);
+	}
 
 	/**
 	 * @see EmailPopulatingBuilder#withAttachment(String, byte[], String, String)
@@ -1749,6 +1756,14 @@ public class EmailPopulatingBuilderImpl implements InternalEmailPopulatingBuilde
 	@Override
 	public EmailPopulatingBuilder withAttachment(@Nullable final String name, final byte@NotNull[] data, @NotNull final String mimetype, @Nullable final String description) {
 		return withAttachment(name, data, mimetype, description, null);
+	}
+
+	/**
+	 * @see EmailPopulatingBuilder#withAttachment(String, String, byte[], String, String)
+	 */
+	@Override
+	public EmailPopulatingBuilder withAttachment(@Nullable final String name, @NotNull final String contentId, final byte@NotNull[] data, @NotNull final String mimetype, @Nullable final String description) {
+		return withAttachment(name, contentId, data, mimetype, description, null);
 	}
 
 	/**
@@ -1765,11 +1780,32 @@ public class EmailPopulatingBuilderImpl implements InternalEmailPopulatingBuilde
 	}
 
 	/**
+	 * @see EmailPopulatingBuilder#withAttachment(String, String, byte[], String, String, ContentTransferEncoding)
+	 */
+	@Override
+	public EmailPopulatingBuilder withAttachment(@Nullable final String name, @NotNull final String contentId, final byte@NotNull[] data, @NotNull final String mimetype, @Nullable final String description, @Nullable final ContentTransferEncoding contentTransferEncoding) {
+		requireNonNull(data, "data");
+		checkNonEmptyArgument(mimetype, "mimetype");
+		final ByteArrayDataSource dataSource = new ByteArrayDataSource(data, mimetype);
+		dataSource.setName(name);
+		withAttachment(name, contentId, dataSource, description, contentTransferEncoding);
+		return this;
+	}
+
+	/**
 	 * @see EmailPopulatingBuilder#withAttachment(String, DataSource)
 	 */
 	@Override
 	public EmailPopulatingBuilder withAttachment(@Nullable final String name, @NotNull final DataSource filedata) {
 		return withAttachment(name, filedata, null, null);
+	}
+
+	/**
+	 * @see EmailPopulatingBuilder#withAttachment(String, String, DataSource)
+	 */
+	@Override
+	public EmailPopulatingBuilder withAttachment(@Nullable final String name, @NotNull final String contentId, @NotNull final DataSource filedata) {
+		return withAttachment(name, contentId, filedata, null, null);
 	}
 
 	/**
@@ -1781,14 +1817,33 @@ public class EmailPopulatingBuilderImpl implements InternalEmailPopulatingBuilde
 	}
 
 	/**
+	 * @see EmailPopulatingBuilder#withAttachment(String, String, DataSource, String)
+	 */
+	@Override
+	public EmailPopulatingBuilder withAttachment(@Nullable final String name, @NotNull final String contentId, @NotNull final DataSource filedata, @Nullable final String description) {
+		return withAttachment(name, contentId, filedata, description, null);
+	}
+
+	/**
 	 * @see EmailPopulatingBuilder#withAttachment(String, DataSource, String, ContentTransferEncoding)
 	 */
 	@Override
 	public EmailPopulatingBuilder withAttachment(@Nullable final String name, @NotNull final DataSource filedata, @Nullable final String description, @Nullable final ContentTransferEncoding contentTransferEncoding) {
 		checkNonEmptyArgument(filedata, "filedata");
-		attachments.add(new AttachmentResource(name, filedata, description, contentTransferEncoding));
+		attachments.add(new AttachmentResource(name, null, filedata, description, contentTransferEncoding));
 		return this;
 	}
+
+	/**
+	 * @see EmailPopulatingBuilder#withAttachment(String, String, DataSource, String, ContentTransferEncoding)
+	 */
+	@Override
+	public EmailPopulatingBuilder withAttachment(@Nullable final String name, @NotNull final String contentId, @NotNull final DataSource filedata, @Nullable final String description, @Nullable final ContentTransferEncoding contentTransferEncoding) {
+		checkNonEmptyArgument(filedata, "filedata");
+		attachments.add(new AttachmentResource(name, contentId, filedata, description, contentTransferEncoding));
+		return this;
+	}
+
 
 	/**
 	 * @see EmailPopulatingBuilder#withAttachments(List)
@@ -1796,7 +1851,12 @@ public class EmailPopulatingBuilderImpl implements InternalEmailPopulatingBuilde
 	@Override
 	public EmailPopulatingBuilder withAttachments(@NotNull final List<AttachmentResource> attachments) {
 		for (final AttachmentResource attachment : attachments) {
-			withAttachment(attachment.getName(), attachment.getDataSource(), attachment.getDescription(), attachment.getContentTransferEncoding());
+			if (valueNullOrEmpty(attachment.getContentId())) {
+				withAttachment(attachment.getName(), attachment.getDataSource(), attachment.getDescription(), attachment.getContentTransferEncoding());
+			}
+			else {
+				withAttachment(attachment.getName(), attachment.getContentId(), attachment.getDataSource(), attachment.getDescription(), attachment.getContentTransferEncoding());
+			}
 		}
 		return this;
 	}

--- a/modules/simple-java-mail/src/test/java/org/simplejavamail/converter/EmailConverterTest.java
+++ b/modules/simple-java-mail/src/test/java/org/simplejavamail/converter/EmailConverterTest.java
@@ -298,7 +298,7 @@ public class EmailConverterTest {
 				.clearAttachments()
 				.withAttachment("dummy text1.txt", dummyAttachment1.getBytes(defaultCharset()), "text/plain", "This is dummy text1", BIT7)
 				.withAttachment("dummy text2.txt", new ByteArrayDataSource(dummyAttachment2, "text/plain"), "This is dummy text2", BIT7)
-				.withAttachments(asList(new AttachmentResource("dummy text3.txt", new ByteArrayDataSource(dummyAttachment3, "text/plain"), "This is dummy text3", BIT7)))
+				.withAttachments(asList(new AttachmentResource("dummy text3.txt", null, new ByteArrayDataSource(dummyAttachment3, "text/plain"), "This is dummy text3", BIT7)))
 				.withAttachment("dummy text4.txt", new ByteArrayDataSource("this should not have a Content-Description header", "text/plain"), null, BIT7)
 				.buildEmail();
 

--- a/modules/simple-java-mail/src/test/java/org/simplejavamail/converter/internal/mimemessage/MimeMessageHelperTest.java
+++ b/modules/simple-java-mail/src/test/java/org/simplejavamail/converter/internal/mimemessage/MimeMessageHelperTest.java
@@ -34,7 +34,7 @@ public class MimeMessageHelperTest {
 	@Test
 	public void determineResourceName1()
 			throws IOException {
-		AttachmentResource resource1 = new AttachmentResource(null, getDataSource("blahblah"));
+		AttachmentResource resource1 = new AttachmentResource(null, null,getDataSource("blahblah"));
 		assertThat(MimeMessageHelper.determineResourceName(resource1, Part.ATTACHMENT, true, false)).isEqualTo("blahblah");
 		assertThat(MimeMessageHelper.determineResourceName(resource1, Part.INLINE, true, false)).isEqualTo("blahblah");
 	}
@@ -42,7 +42,7 @@ public class MimeMessageHelperTest {
 	@Test
 	public void determineResourceName2()
 			throws IOException {
-		AttachmentResource resource2 = new AttachmentResource(null, getDataSource("blahblah.txt"));
+		AttachmentResource resource2 = new AttachmentResource(null, null, getDataSource("blahblah.txt"));
 		assertThat(MimeMessageHelper.determineResourceName(resource2, Part.ATTACHMENT, true, false)).isEqualTo("blahblah.txt");
 		assertThat(MimeMessageHelper.determineResourceName(resource2, Part.INLINE, true, false)).isEqualTo("blahblah.txt");
 	}
@@ -50,7 +50,7 @@ public class MimeMessageHelperTest {
 	@Test
 	public void determineResourceName3()
 			throws IOException {
-		AttachmentResource resource3 = new AttachmentResource("the resource", getDataSource(null));
+		AttachmentResource resource3 = new AttachmentResource("the resource", null, getDataSource(null));
 		assertThat(MimeMessageHelper.determineResourceName(resource3, Part.ATTACHMENT, true, false)).isEqualTo("the resource");
 		assertThat(MimeMessageHelper.determineResourceName(resource3, Part.INLINE, true, false)).isEqualTo("the resource");
 	}
@@ -58,7 +58,7 @@ public class MimeMessageHelperTest {
 	@Test
 	public void determineResourceName4()
 			throws IOException {
-		AttachmentResource resource4 = new AttachmentResource("the resource", getDataSource("blahblah.txt"));
+		AttachmentResource resource4 = new AttachmentResource("the resource", null, getDataSource("blahblah.txt"));
 		assertThat(MimeMessageHelper.determineResourceName(resource4, Part.ATTACHMENT, true, false)).isEqualTo("the resource.txt");
 		assertThat(MimeMessageHelper.determineResourceName(resource4, Part.INLINE, true, false)).isEqualTo("the resource");
 	}
@@ -66,7 +66,7 @@ public class MimeMessageHelperTest {
 	@Test
 	public void determineResourceName5()
 			throws IOException {
-		AttachmentResource resource5 = new AttachmentResource("the resource", getDataSource("blahblah"));
+		AttachmentResource resource5 = new AttachmentResource("the resource", null, getDataSource("blahblah"));
 		assertThat(MimeMessageHelper.determineResourceName(resource5, Part.ATTACHMENT, true, false)).isEqualTo("the resource");
 		assertThat(MimeMessageHelper.determineResourceName(resource5, Part.INLINE, true, false)).isEqualTo("the resource");
 	}
@@ -74,7 +74,7 @@ public class MimeMessageHelperTest {
 	@Test
 	public void determineResourceName6()
 			throws IOException {
-		AttachmentResource resource6 = new AttachmentResource("the resource.txt", getDataSource("blahblah.txt"));
+		AttachmentResource resource6 = new AttachmentResource("the resource.txt", null, getDataSource("blahblah.txt"));
 		assertThat(MimeMessageHelper.determineResourceName(resource6, Part.ATTACHMENT, true, false)).isEqualTo("the resource.txt");
 		assertThat(MimeMessageHelper.determineResourceName(resource6, Part.INLINE, true, false)).isEqualTo("the resource.txt");
 	}
@@ -82,7 +82,7 @@ public class MimeMessageHelperTest {
 	@Test
 	public void determineResourceName7()
 			throws IOException {
-		AttachmentResource resource7 = new AttachmentResource("the resource.txt", getDataSource("blahblah"));
+		AttachmentResource resource7 = new AttachmentResource("the resource.txt", null, getDataSource("blahblah"));
 		assertThat(MimeMessageHelper.determineResourceName(resource7, Part.ATTACHMENT, true, false)).isEqualTo("the resource.txt");
 		assertThat(MimeMessageHelper.determineResourceName(resource7, Part.INLINE, true, false)).isEqualTo("the resource.txt");
 	}
@@ -90,7 +90,7 @@ public class MimeMessageHelperTest {
 	@Test
 	public void determineResourceName_ignoreExtensionFromResource()
 			throws IOException {
-		AttachmentResource resource7 = new AttachmentResource("the resource.txt", getDataSource("blahblah.1/www/get?id=3"));
+		AttachmentResource resource7 = new AttachmentResource("the resource.txt", null, getDataSource("blahblah.1/www/get?id=3"));
 		assertThat(MimeMessageHelper.determineResourceName(resource7, Part.ATTACHMENT, true, false)).isEqualTo("the resource.txt");
 		assertThat(MimeMessageHelper.determineResourceName(resource7, Part.INLINE, true, false)).isEqualTo("the resource.txt");
 	}

--- a/modules/simple-java-mail/src/test/java/org/simplejavamail/converter/internal/mimemessage/MimeMessageParserTest.java
+++ b/modules/simple-java-mail/src/test/java/org/simplejavamail/converter/internal/mimemessage/MimeMessageParserTest.java
@@ -92,7 +92,7 @@ public class MimeMessageParserTest {
 		multipartRootMixed.addBodyPart(messagePart);
 
 		// attachments
-		final AttachmentResource r = new AttachmentResource("wrong-name.txt", new ByteArrayDataSource("Black Tie Optional", "text/plain"));
+		final AttachmentResource r = new AttachmentResource("wrong-name.txt", null, new ByteArrayDataSource("Black Tie Optional", "text/plain"));
 		multipartRootMixed.addBodyPart(getBodyPartFromDatasource(r, Part.ATTACHMENT));
 
 		m.setContent(multipartRootMixed);

--- a/modules/simple-java-mail/src/test/java/org/simplejavamail/email/internal/EmailPopulatingBuilderImpl1Test.java
+++ b/modules/simple-java-mail/src/test/java/org/simplejavamail/email/internal/EmailPopulatingBuilderImpl1Test.java
@@ -741,9 +741,9 @@ public class EmailPopulatingBuilderImpl1Test {
 	@Test
 	public void testWithEmbeddedImages() throws IOException {
 		List<AttachmentResource> embeddedImages = new ArrayList<>();
-		embeddedImages.add(new AttachmentResource("attachment1", getDataSource("blahblah.txt")));
-		embeddedImages.add(new AttachmentResource(null, getDataSource("blahblah.txt")));
-		embeddedImages.add(new AttachmentResource("attachment1", new ByteArrayDataSource("", "text/text")));
+		embeddedImages.add(new AttachmentResource("attachment1", null,getDataSource("blahblah.txt")));
+		embeddedImages.add(new AttachmentResource(null, null, getDataSource("blahblah.txt")));
+		embeddedImages.add(new AttachmentResource("attachment1", null, new ByteArrayDataSource("", "text/text")));
 
 		Email email = builder.withEmbeddedImages(embeddedImages).buildEmail();
 

--- a/modules/simple-java-mail/src/test/java/org/simplejavamail/internal/smimesupport/ReadSmimeAttachmentsTest.java
+++ b/modules/simple-java-mail/src/test/java/org/simplejavamail/internal/smimesupport/ReadSmimeAttachmentsTest.java
@@ -187,7 +187,7 @@ public class ReadSmimeAttachmentsTest {
 		val attachments = builder.getAttachments();
 		builder.clearAttachments();
 		return attachments.stream()
-				.map(att -> new AttachmentResource(att.getName(), att.getDataSource(), att.getDescription(), null))
+				.map(att -> new AttachmentResource(att.getName(), null, att.getDataSource(), att.getDescription(), null))
 				.collect(toList());
 	}
 }

--- a/modules/simple-java-mail/src/test/java/org/simplejavamail/mailer/MailerLiveTest.java
+++ b/modules/simple-java-mail/src/test/java/org/simplejavamail/mailer/MailerLiveTest.java
@@ -543,7 +543,7 @@ public class MailerLiveTest {
 	@NotNull
 	private List<AttachmentResource> fixAttachmentResourcesWith7Bit(final List<AttachmentResource> originalEmailPopulatingBuilder) {
 		return originalEmailPopulatingBuilder.stream()
-				.map(att -> new AttachmentResource(att.getName(), att.getDataSource(), att.getDescription(), ofNullable(att.getContentTransferEncoding()).orElse(BIT7)))
+				.map(att -> new AttachmentResource(att.getName(), null, att.getDataSource(), att.getDescription(), ofNullable(att.getContentTransferEncoding()).orElse(BIT7)))
 				.collect(toList());
 	}
 

--- a/modules/smime-module/src/main/java/org/simplejavamail/internal/smimesupport/SMIMESupport.java
+++ b/modules/smime-module/src/main/java/org/simplejavamail/internal/smimesupport/SMIMESupport.java
@@ -335,7 +335,7 @@ public class SMIMESupport implements SMIMEModule {
 			};
 			decryptedMessage.setContent((Multipart) content);
 			decryptedMessage.writeTo(os);
-			return new AttachmentResource("signed-email.eml", new ByteArrayDataSource(os.toByteArray(), "message/rfc822"));
+			return new AttachmentResource("signed-email.eml", null, new ByteArrayDataSource(os.toByteArray(), "message/rfc822"));
 		}
         LOGGER.warn("S/MIME signed content type not recognized, please raise an issue for {}", content.getClass());
 		return null;


### PR DESCRIPTION
### Purpose:

- This feature enables setting custom Content-IDs for attachments instead of relying on auto-generated ones. This is helpful for maintaining consistent Content-ID references across email rebuilds.

### Changes:

- Added option to set custom Content-ID when adding attachments