### PR TITLE
build: update Java 8-compatible Maven tooling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,9 @@ updates:
       - dependency-name: "com.mycila:license-maven-plugin"
         versions:
           - "[5,)"
+      - dependency-name: "org.apache.felix:maven-bundle-plugin"
+        versions:
+          - "[6,)"
       - dependency-name: "org.apache.karaf.tooling:karaf-maven-plugin"
         versions:
-          - "[4.4.11,)"
+          - "[4.4.8,)"

--- a/modules/core-module/pom.xml
+++ b/modules/core-module/pom.xml
@@ -32,6 +32,7 @@
                         </Export-Package>
                         <Import-Package>
                             !org.jacoco.*,
+                            org.bouncycastle.jce.provider;resolution:=optional,
                             *
                         </Import-Package>
                     </instructions>

--- a/modules/core-test-module/pom.xml
+++ b/modules/core-test-module/pom.xml
@@ -20,6 +20,24 @@
         <automaticModuleName>org.simplejavamail.test</automaticModuleName>
     </properties>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Import-Package>
+                            org.simplejavamail.internal.moduleloader;resolution:=optional,
+                            org.simplejavamail.mailer.internal;resolution:=optional,
+                            *
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>org.simplejavamail</groupId>

--- a/modules/karaf-module/pom.xml
+++ b/modules/karaf-module/pom.xml
@@ -21,7 +21,7 @@
 			<plugin>
 				<groupId>org.apache.karaf.tooling</groupId>
 				<artifactId>karaf-maven-plugin</artifactId>
-				<version>4.4.3</version>
+				<version>4.4.7</version>
 				<extensions>true</extensions>
 				<configuration>
 					<excludedArtifactIds>

--- a/pom.xml
+++ b/pom.xml
@@ -276,7 +276,7 @@
             <dependency>
                 <groupId>org.jetbrains</groupId>
                 <artifactId>annotations</artifactId>
-                <version>16.0.3</version>
+                <version>26.1.0</version>
             </dependency>
             <dependency><!-- Gives us SpotBugs suppression annotations. -->
                 <groupId>com.github.spotbugs</groupId>
@@ -346,7 +346,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.14.1</version>
+                    <version>3.15.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -366,12 +366,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>3.5.1</version>
+                    <version>5.1.9</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Summary

- update JetBrains annotations from 16.0.3 to 26.1.0
- update Maven Compiler Plugin from 3.14.1 to 3.15.0
- update Maven JAR Plugin from 3.1.0 to 3.5.0
- update Felix Maven Bundle Plugin from 3.5.1 to 5.1.9, the latest Java 8-compatible line
- update Karaf Maven Plugin from 4.4.3 to 4.4.7, the latest Java 8-compatible line
- keep bnd's newly detected reflective OSGi imports optional
- prevent Dependabot from proposing Felix 6+ or Karaf 4.4.8+, which require newer Java runtimes

## Why the Dependabot versions were adjusted

Felix Maven Bundle Plugin 6.x upgrades to bnd 7 and requires Java 17. Karaf Maven Plugin 4.4.10 contains Java 11 bytecode and declares Java `[11,)` plus Maven 3.9.12. Both conflict with the project's Java 8 support requirement.

## Validation

- `mvn -B -ntp clean verify` — passed on Oracle JDK 8u152 with Maven 3.9.10, all 13 modules
- `mvn -B -ntp -DskipTests clean package` — passed on JDK 21, all 13 modules including Karaf feature verification
- compared old/new plugin JAR contents and descriptors; selected plugins execute on Java 8 and retain every configured goal/parameter
- compared generated project JARs entry-by-entry; all ten main JARs retain identical entry sets and ordinary class contents
- verified changed OSGi imports are explicitly optional and Java 9 module descriptors retain the same exported/required modules

The pre-existing test suite on JDK 21 still has 15 reflection-related errors in configuration test helpers; the same failures occur on unmodified `develop`.